### PR TITLE
[FIX]: 웹 브릿지 타입 오류 수정

### DIFF
--- a/web/src/types/bridge/bridge.types.ts
+++ b/web/src/types/bridge/bridge.types.ts
@@ -22,6 +22,7 @@ export interface FailureBridgeResult {
 export type BridgeLoginResult = SuccessBridgeResult | FailureBridgeResult;
 
 export interface AppState {
+  [key: string]: RawJSON;
   isLoggedIn: boolean;
 }
 
@@ -31,14 +32,6 @@ export interface NativeBridgeMethods {
   refreshTokens: () => Promise<{ accessToken: string | null }>;
 }
 
-export interface AppBridgeState {
-  [key: string]: RawJSON;
-  isLoggedIn: boolean;
-}
+export type AppBridgeSpec = AppState & NativeBridgeMethods;
 
-export interface AppBridge extends BridgeStore<AppBridgeState> {
-  // 네이티브 브릿지가 제공하는 함수들
-  socialLogin: (type: SocialType) => Promise<BridgeLoginResult>;
-  getAccessToken: () => Promise<{ accessToken: string | null }>;
-  refreshTokens: () => Promise<{ accessToken: string | null }>;
-}
+export type AppBridge = BridgeStore<AppBridgeSpec>;


### PR DESCRIPTION
## 개요

Merge시, 브릿지 타입 수정했던 곳에서 오류가 나서 다시 라이브러리 깃허브보고 수정 했습니다! 
이제는 타입 오류 안납니다... 