### PR TITLE
[FEAT]: SelectBox 컴포넌트 구현 

### DIFF
--- a/web/src/components/common/BottomFullButton.tsx
+++ b/web/src/components/common/BottomFullButton.tsx
@@ -4,21 +4,27 @@ export interface BottomFullButtonProps {
   state: boolean;
   onClick: () => void;
   content: string;
+  className?: string;
 }
 export const BottomFullButton = ({
   state = true,
   onClick,
   content,
+  className,
 }: BottomFullButtonProps) => {
   return (
     <button
       type="button"
       onClick={onClick}
       disabled={!state}
-      className={cn("w-full rounded-xl py-3.5", {
-        "bg-primary-400 text-base-0 body-1-bold": state,
-        "bg-base-50 text-gray-system-500 body-2-medium": !state,
-      })}
+      className={cn(
+        "w-full rounded-xl py-3.5",
+        {
+          "bg-primary-400 text-base-0 body-1-bold": state,
+          "bg-base-50 text-gray-system-500 body-2-medium": !state,
+        },
+        className,
+      )}
     >
       {content}
     </button>

--- a/web/src/components/common/PostMenuButton.tsx
+++ b/web/src/components/common/PostMenuButton.tsx
@@ -3,8 +3,8 @@ import { useState } from "react";
 import { BottomSheet } from "@/components/common/BottomSheet";
 import { ConfirmModal } from "@/components/common/ConfirmModal";
 import { ReportPostSheet } from "@/components/common/ReportPostSheet";
+import { SelectBox } from "@/components/common/SelectBox";
 
-import ArrowRightIcon from "@/assets/icons/arrow_right.svg?react";
 import CommunityPostMenuIcon from "@/assets/icons/community_post_menu.svg?react";
 
 type ViewState = "closed" | "menu" | "block" | "report" | "reportComplete";
@@ -26,23 +26,16 @@ export const PostMenuButton = () => {
         onClose={() => setViewState("closed")}
       >
         <div className="mx-5 my-[1.875rem] flex flex-col gap-2.5">
-          {/* TODO: @tifsy 컴포넌트로 분리  */}
-          <button
-            className="bg-base-50 flex h-15 w-full items-center justify-between rounded-xl px-5"
+          <SelectBox
+            type="postMenu"
+            label="해당 유저 차단하기"
             onClick={() => setViewState("block")}
-          >
-            <p className="body-2-medium text-gray-system-200">
-              해당 유저 차단하기
-            </p>
-            <ArrowRightIcon />
-          </button>
-          <button
-            className="bg-base-50 flex h-15 w-full items-center justify-between rounded-xl px-5"
+          />
+          <SelectBox
+            type="postMenu"
+            label="신고하기"
             onClick={() => setViewState("report")}
-          >
-            <p className="body-2-medium text-gray-system-200">신고하기</p>
-            <ArrowRightIcon />
-          </button>
+          />
         </div>
       </BottomSheet>
 

--- a/web/src/components/common/ReportPostSheet.tsx
+++ b/web/src/components/common/ReportPostSheet.tsx
@@ -1,14 +1,10 @@
 import { useState, useEffect } from "react";
 
-import { cn } from "@/utils/cn";
-
 import { BottomFullButton } from "@/components/common/BottomFullButton";
 import { BottomSheet } from "@/components/common/BottomSheet";
+import { SelectBox } from "@/components/common/SelectBox";
 
 import { REPORT_REASONS } from "@/constants/reportReasons";
-
-import CheckboxOffIcon from "@/assets/icons/checkbox_off.svg?react";
-import CheckboxOnIcon from "@/assets/icons/checkbox_on.svg?react";
 
 interface ReportPostSheetProps {
   isOpen: boolean;
@@ -57,40 +53,23 @@ export const ReportPostSheet = ({
         </div>
         <div className="bg-base-50 my-2 h-[1px]" />
 
-        <div className="mx-5 mb-[22px] flex flex-col gap-[10px]">
-          {/* TODO: @tifsy 컴포넌트로 분리  */}
+        <div className="mx-5 flex flex-col gap-3">
           {REPORT_REASONS.map((reason) => (
-            <button
+            <SelectBox
               key={reason}
+              type="reportSheet"
+              label={reason}
               onClick={() => handleSelect(reason)}
-              className={cn(
-                "bg-base-50 flex h-15 w-full items-center justify-between rounded-xl px-5",
-                selectedReason === reason &&
-                  "border-primary-500 bg-primary-0 border",
-              )}
-            >
-              <span
-                className={cn(
-                  "body-2-medium text-gray-system-200",
-                  selectedReason === reason && "text-primary-200",
-                )}
-              >
-                {reason}
-              </span>
-              {selectedReason === reason ? (
-                <CheckboxOnIcon />
-              ) : (
-                <CheckboxOffIcon />
-              )}
-            </button>
+              isSelected={selectedReason === reason}
+            />
           ))}
+          <BottomFullButton
+            state={!!selectedReason}
+            onClick={handleReport}
+            content="신고하기"
+            className="mt-5"
+          />
         </div>
-
-        <BottomFullButton
-          state={!!selectedReason}
-          onClick={handleReport}
-          content="신고하기"
-        />
       </div>
     </BottomSheet>
   );

--- a/web/src/components/common/SelectBox.tsx
+++ b/web/src/components/common/SelectBox.tsx
@@ -37,7 +37,7 @@ const SELECT_BOX_CONFIG: Record<
     default:
       "bg-base-50 text-gray-system-400  border-[0.5px] border-gray-system-700",
     selected:
-      "bg-primary-0 text-primary-200 border-blue-300 border-[1px] border-primary-400",
+      "bg-primary-0 text-primary-200 border-blue-300 border border-primary-400",
     icon: (isSelected) =>
       isSelected ? <CheckboxOnIcon /> : <CheckboxOffIcon />,
   },

--- a/web/src/components/common/SelectBox.tsx
+++ b/web/src/components/common/SelectBox.tsx
@@ -1,0 +1,70 @@
+import { cn } from "@/utils/cn";
+
+import ArrowRightIcon from "@/assets/icons/arrow_right.svg?react";
+import CheckOffIcon from "@/assets/icons/check_off.svg?react";
+import CheckOnIcon from "@/assets/icons/check_on.svg?react";
+import CheckboxOffIcon from "@/assets/icons/checkbox_off.svg?react";
+import CheckboxOnIcon from "@/assets/icons/checkbox_on.svg?react";
+
+type SelectBoxType = "onboarding" | "postMenu" | "reportSheet";
+
+interface SelectBoxProps {
+  type: SelectBoxType;
+  label: string | null;
+  onClick?: () => void;
+  isSelected?: boolean;
+}
+const SELECT_BOX_CONFIG: Record<
+  SelectBoxType,
+  {
+    default: string;
+    selected?: string;
+    icon: (isSelected: boolean) => React.ReactNode;
+  }
+> = {
+  onboarding: {
+    default:
+      "bg-[#2C2D3066] text-gray-system-600 border-[0.5px] border-gray-system-700",
+    selected:
+      "bg-primary-0 text-primary-200 border-blue-300 border-[1px] border-primary-400",
+    icon: (isSelected) => (isSelected ? <CheckOnIcon /> : <CheckOffIcon />),
+  },
+  postMenu: {
+    default: "bg-base-50 text-gray-system-200",
+    icon: () => <ArrowRightIcon />,
+  },
+  reportSheet: {
+    default:
+      "bg-base-50 text-gray-system-400  border-[0.5px] border-gray-system-700",
+    selected:
+      "bg-primary-0 text-primary-200 border-blue-300 border-[1px] border-primary-400",
+    icon: (isSelected) =>
+      isSelected ? <CheckboxOnIcon /> : <CheckboxOffIcon />,
+  },
+};
+
+export const SelectBox = ({
+  type,
+  label,
+  onClick,
+  isSelected = false,
+}: SelectBoxProps) => {
+  const {
+    default: defaultStyle,
+    selected: selectedStyle,
+    icon,
+  } = SELECT_BOX_CONFIG[type];
+
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "flex h-15 w-full items-center justify-between rounded-xl px-5 transition-colors duration-50",
+        isSelected ? selectedStyle : defaultStyle,
+      )}
+    >
+      <span className="body-2-medium">{label}</span>
+      <span className="h-6 w-6 [&>*]:h-6 [&>*]:w-6">{icon(isSelected)}</span>
+    </button>
+  );
+};

--- a/web/src/components/signup/AgeForm.tsx
+++ b/web/src/components/signup/AgeForm.tsx
@@ -1,7 +1,6 @@
 import type { Age } from "@/types/signup/signup.types";
-import CheckOn from "@/assets/icons/check_on.svg?react";
-import CheckOff from "@/assets/icons/check_off.svg?react";
-import { cn } from "@/utils/cn";
+
+import { SelectBox } from "@/components/common/SelectBox";
 
 const AGE_OPTIONS: Age[] = ["10~20대", "30~40대", "50~60대", "60대 이상"];
 
@@ -48,28 +47,13 @@ const AgeSelect = ({ ageOption, selectedAge, onSelect }: AgeSelectProps) => {
   const isSelected = ageOption === selectedAge;
 
   return (
-    <button
-      type="button"
-      role="radio"
-      aria-checked={isSelected}
-      onClick={() => onSelect(ageOption)}
-      className={cn(
-        "body-2-medium flex items-center justify-between rounded-xl px-5 py-[1.125rem] text-left",
-        {
-          /* TODO: @Ki-Tak 추후에 디자인 시스템 변경시 배경화면 팔레트 변경해야함*/
-          "text-primary-200 border-primary-400 border bg-[#2f47bd4d]":
-            isSelected,
-          "bg-base-50 text-gray-system-600 border-gray-system-700 border-[0.5px]":
-            !isSelected,
-        },
-      )}
-    >
-      <p>{ageOption}</p>
-      {isSelected ? (
-        <CheckOn className="h-6 w-6" />
-      ) : (
-        <CheckOff className="h-6 w-6" />
-      )}
-    </button>
+    <>
+      <SelectBox
+        type="onboarding"
+        label={ageOption}
+        isSelected={isSelected}
+        onClick={() => onSelect(ageOption)}
+      />
+    </>
   );
 };

--- a/web/src/components/signup/GenderForm.tsx
+++ b/web/src/components/signup/GenderForm.tsx
@@ -1,7 +1,8 @@
 import type { Gender } from "@/types/signup/signup.types";
-import CheckOn from "@/assets/icons/check_on.svg?react";
-import CheckOff from "@/assets/icons/check_off.svg?react";
 import { cn } from "@/utils/cn";
+
+import CheckOff from "@/assets/icons/check_off.svg?react";
+import CheckOn from "@/assets/icons/check_on.svg?react";
 
 const GENDER_OPTIONS: Gender[] = ["남자", "여자"];
 

--- a/web/src/components/signup/MethodForm.tsx
+++ b/web/src/components/signup/MethodForm.tsx
@@ -1,8 +1,6 @@
 import type { TradeMethod } from "@/types/signup/signup.types";
-import { cn } from "@/utils/cn";
 
-import CheckOff from "@/assets/icons/check_off.svg?react";
-import CheckOn from "@/assets/icons/check_on.svg?react";
+import { SelectBox } from "@/components/common/SelectBox";
 
 const TRADE_METHOD_OPTIONS: TradeMethod[] = [
   "SNS 거래",
@@ -64,25 +62,11 @@ const MethodSelect = ({
   onSelect,
 }: MethodSelectProps) => {
   return (
-    <button
-      type="button"
+    <SelectBox
+      type="onboarding"
+      label={methodOption}
+      isSelected={isSelected}
       onClick={() => onSelect(methodOption)}
-      className={cn(
-        "body-2-medium flex items-center justify-between rounded-xl px-5 py-[1.125rem] text-left",
-        {
-          "text-primary-200 border-primary-400 border bg-[#2f47bd4d]":
-            isSelected,
-          "bg-base-50 text-gray-system-600 border-gray-system-700 border-[0.5px]":
-            !isSelected,
-        },
-      )}
-    >
-      <p>{methodOption}</p>
-      {isSelected ? (
-        <CheckOn className="h-6 w-6" />
-      ) : (
-        <CheckOff className="h-6 w-6" />
-      )}
-    </button>
+    />
   );
 };


### PR DESCRIPTION
## 개요

온보딩, 커뮤니티에서 공통으로 사용되는 SelectBox 컴포넌트를 구현합니다. 
Resolves: #31 

## PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [X] 코드 리팩토링

## 작업 내용
### 1. SelectBox 컴포넌트 구현 및 적용
**재사용 가능한 선택 컴포넌트 구현**
- 공통 UI 패턴인 선택 박스를 컴포넌트로 분리하여 재사용성을 높였습니다.
- 사용 목적에 따라 스타일과 아이콘 구성이 달라지도록 type prop을 통해 분기 처리하며, 시나리오에 맞는 UI/UX를 유지합니다.
- 내부적으로 선택 여부에 따라 스타일 변경 및 아이콘을 다르게 표시합니다.

**props 동작**
💠는 **필수 prop**입니다.

| prop        | 설명 |
|-------------|------|
| `type`💠     | SelectBox 유형 (`'onboarding'` | `'postMenu'` | `'reportStreet'` |
| `label`💠 | SelectBox에 표시할 텍스트 |
| `isSelected`      | 선택 여부 상태 (선택 시 스타일 및 아이콘 변경) |
| `onClick`   | 버튼 클릭 시 호출될 함수 |

**적용된 위치**
- 온보딩
- 커뮤니티 게시글 옵션 바텀시트
- 게시글 신고 바텀시트 

## 공유사항 to 리뷰어

코드에 개선사항이 있다면 알려주세요 😵‍💫

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
