### PR TITLE
[FEAT]: CategoryTagGroup 컴포넌트 구현

### DIFF
--- a/web/src/components/common/CategoryTagGroup.tsx
+++ b/web/src/components/common/CategoryTagGroup.tsx
@@ -1,0 +1,33 @@
+import { cn } from "@/utils/cn";
+
+interface CategoryTagGroupProps {
+  tags: string[];
+  selected: string;
+  onSelect: (tag: string) => void;
+}
+
+export const CategoryTagGroup: React.FC<CategoryTagGroupProps> = ({
+  tags,
+  selected,
+  onSelect,
+}) => {
+  return (
+    <div className="flex gap-2">
+      {tags.map((tag) => (
+        <button
+          key={tag}
+          type="button"
+          onClick={() => onSelect(tag)}
+          className={cn(
+            "body-2-medium h-9 content-center rounded-full px-3 transition-colors",
+            selected === tag
+              ? "bg-primary-400 text-base-0"
+              : "bg-bg-50 text-gray-system-500",
+          )}
+        >
+          {tag}
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/web/src/components/common/CategoryTagGroup.tsx
+++ b/web/src/components/common/CategoryTagGroup.tsx
@@ -4,15 +4,17 @@ interface CategoryTagGroupProps {
   tags: string[];
   selected: string;
   onSelect: (tag: string) => void;
+  className?: string;
 }
 
 export const CategoryTagGroup: React.FC<CategoryTagGroupProps> = ({
   tags,
   selected,
   onSelect,
+  className,
 }) => {
   return (
-    <div className="flex flex-wrap gap-2 gap-y-2">
+    <div className={cn("flex flex-wrap gap-x-2 gap-y-2", className)}>
       {tags.map((tag) => (
         <button
           key={tag}

--- a/web/src/components/common/CategoryTagGroup.tsx
+++ b/web/src/components/common/CategoryTagGroup.tsx
@@ -19,7 +19,7 @@ export const CategoryTagGroup: React.FC<CategoryTagGroupProps> = ({
           type="button"
           onClick={() => onSelect(tag)}
           className={cn(
-            "body-2-medium h-9 content-center rounded-full px-3 transition-colors",
+            "body-2-medium min-width-20 h-9 content-center rounded-full px-2 transition-colors",
             selected === tag
               ? "bg-primary-400 text-base-0"
               : "bg-bg-50 text-gray-system-500",

--- a/web/src/components/common/CategoryTagGroup.tsx
+++ b/web/src/components/common/CategoryTagGroup.tsx
@@ -14,11 +14,16 @@ export const CategoryTagGroup: React.FC<CategoryTagGroupProps> = ({
   className,
 }) => {
   return (
-    <div className={cn("flex flex-wrap gap-x-2 gap-y-2", className)}>
+    <div
+      className={cn("flex flex-wrap gap-x-2 gap-y-2", className)}
+      role="radiogroup"
+    >
       {tags.map((tag) => (
         <button
           key={tag}
           type="button"
+          role="radio"
+          aria-checked={selected === tag}
           onClick={() => onSelect(tag)}
           className={cn(
             "body-2-medium min-width-20 h-9 content-center rounded-full px-2 transition-colors",

--- a/web/src/components/common/CategoryTagGroup.tsx
+++ b/web/src/components/common/CategoryTagGroup.tsx
@@ -12,7 +12,7 @@ export const CategoryTagGroup: React.FC<CategoryTagGroupProps> = ({
   onSelect,
 }) => {
   return (
-    <div className="flex gap-2">
+    <div className="flex flex-wrap gap-2 gap-y-2">
       {tags.map((tag) => (
         <button
           key={tag}


### PR DESCRIPTION
## 개요

아티클 피드와 글 작성 페이지에서 공통으로 사용되는 CategoryTagGroup 컴포넌트를 구현합니다
Resolves: #45 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

## 작업 내용
### 1. SelectBox 컴포넌트 구현 및 적용
**카테고리 선택용 태그 그룹 컴포넌트 구현**
- 커뮤니티 글 작성 등에서 반복되는 태그 선택 UI를 컴포넌트로 분리하여 재사용성을 높였습니다.
- 선택된 태그는 강조 스타일로 시각적으로 구분되며, 태그가 많을 경우 자동으로 줄바꿈되도록 처리하였습니다.
- 컴포넌트 외부에서 선택 상태를 관리하며, 클릭 시 선택값을 변경하는 콜백을 호출합니다.

**props 동작**
💠는 **필수 prop**입니다.

| prop        | 설명 |
|-------------|------|
| `tags`💠   | 렌더링할 태그 문자열 배열 |
| `selected`💠 | 현재 선택된 태그 (스타일이 강조됩니다) |
| `onSelect` 💠 | 태그 클릭 시 호출될 콜백 함수 |
| `className`   | 최상위 wrapper(div)에 전달할 커스텀 클래스명 |

**적용된 위치**
- 커뮤니티 글 작성 화면
- 컨텐츠 피드 화면

## 공유사항 to 리뷰어

코드에 개선점이 있다면 알려주세요 💭

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

