### PR TITLE
[FEAT]: 커뮤니티 글 작성 화면 UI 구현

### DIFF
--- a/web/src/assets/icons/add.svg
+++ b/web/src/assets/icons/add.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15 15L10 10M10 10L5 5M10 10L15 5M10 10L5 15" stroke="#8E8E93" stroke-width="0.8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/web/src/assets/icons/delete.svg
+++ b/web/src/assets/icons/delete.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="20" height="20" rx="10" fill="#4C4E51"/>
+<path d="M15 10L5 10" stroke="#8E8E93" stroke-width="1.45455" stroke-linecap="round"/>
+</svg>

--- a/web/src/components/communityWrite/CommunityWriteForm.tsx
+++ b/web/src/components/communityWrite/CommunityWriteForm.tsx
@@ -5,7 +5,7 @@ export const CommunityWriteForm = ({
   onChange,
 }: {
   value: string;
-  onChange: (val: string) => void;
+  onChange: (value: string) => void;
 }) => {
   return (
     <div>

--- a/web/src/components/communityWrite/CommunityWriteForm.tsx
+++ b/web/src/components/communityWrite/CommunityWriteForm.tsx
@@ -1,0 +1,25 @@
+import { FormTextarea } from "@/components/common/FormTextarea";
+
+export const CommunityWriteForm = ({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (val: string) => void;
+}) => {
+  return (
+    <div>
+      <h1 className="head-4-semibold text-base-0 pb-3">
+        내용을 입력해주세요.<span className="text-primary-400">*</span>
+      </h1>
+      <FormTextarea
+        id="community_write"
+        value={value}
+        type="Write"
+        onChange={onChange}
+        maxLength={500}
+        placeholder="최소 10자 이상 작성해주세요."
+      />
+    </div>
+  );
+};

--- a/web/src/components/communityWrite/PostBoardSelect.tsx
+++ b/web/src/components/communityWrite/PostBoardSelect.tsx
@@ -7,7 +7,7 @@ export const PostBoardSelect = ({
   onChange,
 }: {
   value: string;
-  onChange: (val: string) => void;
+  onChange: (value: string) => void;
 }) => {
   return (
     <div>

--- a/web/src/components/communityWrite/PostBoardSelect.tsx
+++ b/web/src/components/communityWrite/PostBoardSelect.tsx
@@ -1,0 +1,40 @@
+import { cn } from "@/utils/cn";
+
+import { COMMUNITY_FEED_TABS } from "@/constants/commnityFeedTabs";
+
+export const PostBoardSelect = ({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (val: string) => void;
+}) => {
+  return (
+    <div>
+      <h1 className="head-4-semibold text-base-0 pb-3">
+        게시판을 선택해주세요.<span className="text-primary-400">*</span>
+      </h1>
+
+      {/* TODO: @tifsy CategoryTagGroup 컴포넌트 적용  */}
+      <div className="flex gap-2">
+        {COMMUNITY_FEED_TABS.map((tab) => {
+          const isSelected = value === tab;
+          return (
+            <button
+              key={tab}
+              onClick={() => onChange(tab)}
+              className={cn(
+                "body-2-medium h-9 content-center rounded-full px-3 transition-colors",
+                isSelected
+                  ? "bg-primary-400 text-base-0"
+                  : "bg-bg-50 text-gray-system-500",
+              )}
+            >
+              {tab}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/web/src/components/communityWrite/PostImageUploader.tsx
+++ b/web/src/components/communityWrite/PostImageUploader.tsx
@@ -10,7 +10,7 @@ export const PostImageUploader = ({
   onChange,
 }: {
   value: UploadedImage[];
-  onChange: (val: UploadedImage[]) => void;
+  onChange: (value: UploadedImage[]) => void;
 }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
 

--- a/web/src/components/communityWrite/PostImageUploader.tsx
+++ b/web/src/components/communityWrite/PostImageUploader.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useRef, useEffect } from "react";
 
 import type { UploadedImage } from "@/types/communityWrite/communityWrite.types";
 import { cn } from "@/utils/cn";
@@ -38,6 +38,14 @@ export const PostImageUploader = ({
     URL.revokeObjectURL(value[indexToRemove].previewUrl);
     onChange(updatedImages);
   };
+
+  useEffect(() => {
+    return () => {
+      value.forEach((image) => {
+        URL.revokeObjectURL(image.previewUrl);
+      });
+    };
+  }, []);
 
   return (
     <div>

--- a/web/src/components/communityWrite/PostImageUploader.tsx
+++ b/web/src/components/communityWrite/PostImageUploader.tsx
@@ -4,6 +4,7 @@ import type { UploadedImage } from "@/types/communityWrite/communityWrite.types"
 import { cn } from "@/utils/cn";
 
 import AddIcon from "@/assets/icons/add.svg?react";
+import DeleteIcon from "@/assets/icons/delete.svg?react";
 
 export const PostImageUploader = ({
   value,
@@ -32,6 +33,12 @@ export const PostImageUploader = ({
     onChange([...value, ...previews]);
   };
 
+  const handleRemoveImage = (indexToRemove: number) => {
+    const updatedImages = value.filter((_, index) => index !== indexToRemove);
+    URL.revokeObjectURL(value[indexToRemove].previewUrl);
+    onChange(updatedImages);
+  };
+
   return (
     <div>
       <div className="flex flex-col gap-[3px] pb-3">
@@ -56,12 +63,24 @@ export const PostImageUploader = ({
         )}
 
         {value.map((item, index) => (
-          <img
+          <div
             key={item.previewUrl}
-            src={item.previewUrl}
-            alt={`미리보기 이미지 ${index + 1}`}
-            className="border-gray-system-700 h-[6.25rem] w-[6.25rem] shrink-0 rounded-lg border object-cover"
-          />
+            className="relative h-[6.25rem] w-[6.25rem] shrink-0"
+          >
+            <img
+              src={item.previewUrl}
+              alt={`미리보기 이미지 ${index + 1}`}
+              className="border-gray-system-700 h-full w-full rounded-lg border object-cover"
+            />
+            <button
+              type="button"
+              onClick={() => handleRemoveImage(index)}
+              className="absolute top-[0.5rem] right-[0.5rem]"
+              aria-label={`미리보기 이미지 ${index + 1} 삭제`}
+            >
+              <DeleteIcon />
+            </button>
+          </div>
         ))}
       </div>
 

--- a/web/src/components/communityWrite/PostImageUploader.tsx
+++ b/web/src/components/communityWrite/PostImageUploader.tsx
@@ -1,0 +1,78 @@
+import { useRef } from "react";
+
+import type { UploadedImage } from "@/types/communityWrite/communityWrite.types";
+import { cn } from "@/utils/cn";
+
+import AddIcon from "@/assets/icons/add.svg?react";
+
+export const PostImageUploader = ({
+  value,
+  onChange,
+}: {
+  value: UploadedImage[];
+  onChange: (val: UploadedImage[]) => void;
+}) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files;
+    if (!files || files.length === 0) return;
+
+    const fileArray = Array.from(files).slice(0, 5 - value.length);
+
+    const previews = fileArray.map((file) => ({
+      file,
+      previewUrl: URL.createObjectURL(file),
+    }));
+
+    onChange([...value, ...previews]);
+  };
+
+  return (
+    <div>
+      <div className="flex flex-col gap-[3px] pb-3">
+        <h1 className="head-4-semibold text-base-0">사진을 등록해주세요.</h1>
+        <span className="body-4-medium text-gray-system-400">
+          최대 5장까지 가능해요.
+        </span>
+      </div>
+
+      <div className="scrollbar-hide mt-2 flex gap-2 overflow-x-auto">
+        {value.length < 5 && (
+          <button
+            type="button"
+            onClick={handleClick}
+            className={cn(
+              "flex h-[102px] w-[100px] shrink-0 items-center justify-center rounded-[8px]",
+              "bg-gray-system-800 border-gray-system-700 border-[0.5px]",
+            )}
+          >
+            <AddIcon className="h-6 w-6 rotate-45" />
+          </button>
+        )}
+
+        {value.map((item) => (
+          <img
+            key={item.previewUrl}
+            src={item.previewUrl}
+            alt="preview"
+            className="border-gray-system-700 h-[102px] w-[100px] shrink-0 rounded-[8px] border object-cover"
+          />
+        ))}
+      </div>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        hidden
+        onChange={handleChange}
+      />
+    </div>
+  );
+};

--- a/web/src/components/communityWrite/PostImageUploader.tsx
+++ b/web/src/components/communityWrite/PostImageUploader.tsx
@@ -47,7 +47,7 @@ export const PostImageUploader = ({
             type="button"
             onClick={handleClick}
             className={cn(
-              "flex h-[102px] w-[100px] shrink-0 items-center justify-center rounded-[8px]",
+              "flex h-[6.25rem] w-[6.25rem] shrink-0 items-center justify-center rounded-lg",
               "bg-gray-system-800 border-gray-system-700 border-[0.5px]",
             )}
           >
@@ -60,7 +60,7 @@ export const PostImageUploader = ({
             key={item.previewUrl}
             src={item.previewUrl}
             alt={`미리보기 이미지 ${index + 1}`}
-            className="border-gray-system-700 h-[102px] w-[100px] shrink-0 rounded-[8px] border object-cover"
+            className="border-gray-system-700 h-[6.25rem] w-[6.25rem] shrink-0 rounded-lg border object-cover"
           />
         ))}
       </div>

--- a/web/src/components/communityWrite/PostImageUploader.tsx
+++ b/web/src/components/communityWrite/PostImageUploader.tsx
@@ -55,11 +55,11 @@ export const PostImageUploader = ({
           </button>
         )}
 
-        {value.map((item) => (
+        {value.map((item, index) => (
           <img
             key={item.previewUrl}
             src={item.previewUrl}
-            alt="preview"
+            alt={`미리보기 이미지 ${index + 1}`}
             className="border-gray-system-700 h-[102px] w-[100px] shrink-0 rounded-[8px] border object-cover"
           />
         ))}

--- a/web/src/components/communityWrite/TitleForm.tsx
+++ b/web/src/components/communityWrite/TitleForm.tsx
@@ -1,0 +1,48 @@
+import { type ChangeEvent } from "react";
+
+import { cn } from "@/utils/cn";
+
+import CloseButton from "@/assets/icons/close_button.svg?react";
+
+interface TitleFormProps {
+  title: string;
+  onChange: (value: string) => void;
+}
+
+export const TitleForm = ({ title, onChange }: TitleFormProps) => {
+  const isInputFocus = title.length > 0;
+
+  return (
+    <div>
+      <h1 className="head-4-semibold text-base-0 pb-3">
+        글 제목을 입력해주세요.
+        <span className="text-primary-400">*</span>
+      </h1>
+      <label htmlFor="nicknameInput" className="relative h-fit w-full">
+        <input
+          id="nicknameInput"
+          placeholder="최소 10자 이상 작성해주세요."
+          className={cn(
+            "body-3-regular w-full border-b p-3 overflow-ellipsis transition-colors outline-none",
+            isInputFocus || title.length > 0
+              ? "border-b-primary-400 text-gray-system-400"
+              : "border-b-gray-system-700 text-gray-system-600",
+          )}
+          value={title}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            onChange(e.target.value)
+          }
+        />
+
+        {title.length > 0 && (
+          <button
+            onClick={() => onChange("")}
+            className="absolute top-1/2 right-4 h-[1.375rem] w-[1.375rem] -translate-y-1/2 rounded-full"
+          >
+            <CloseButton className="h-[1.375rem] w-[1.375rem]" />
+          </button>
+        )}
+      </label>
+    </div>
+  );
+};

--- a/web/src/components/communityWrite/TitleForm.tsx
+++ b/web/src/components/communityWrite/TitleForm.tsx
@@ -26,7 +26,7 @@ export const TitleForm = ({ title, onChange }: TitleFormProps) => {
             "body-3-regular w-full border-b p-3 overflow-ellipsis transition-colors outline-none",
             isInputFocus
               ? "border-b-primary-400 text-gray-system-400"
-              : "border-b-gray-system-700 text-gray-system-600",
+              : "border-b-gray-system-700 text-gray-system-400",
           )}
           value={title}
           onChange={(e: ChangeEvent<HTMLInputElement>) =>

--- a/web/src/components/communityWrite/TitleForm.tsx
+++ b/web/src/components/communityWrite/TitleForm.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent } from "react";
+import { useState, type ChangeEvent } from "react";
 
 import { cn } from "@/utils/cn";
 
@@ -10,7 +10,7 @@ interface TitleFormProps {
 }
 
 export const TitleForm = ({ title, onChange }: TitleFormProps) => {
-  const isInputFocus = title.length > 0;
+  const [isInputFocus, setIsInputFocus] = useState(false);
 
   return (
     <div>
@@ -24,7 +24,7 @@ export const TitleForm = ({ title, onChange }: TitleFormProps) => {
           placeholder="최소 10자 이상 작성해주세요."
           className={cn(
             "body-3-regular w-full border-b p-3 overflow-ellipsis transition-colors outline-none",
-            isInputFocus || title.length > 0
+            isInputFocus
               ? "border-b-primary-400 text-gray-system-400"
               : "border-b-gray-system-700 text-gray-system-600",
           )}
@@ -32,6 +32,8 @@ export const TitleForm = ({ title, onChange }: TitleFormProps) => {
           onChange={(e: ChangeEvent<HTMLInputElement>) =>
             onChange(e.target.value)
           }
+          onFocus={() => setIsInputFocus(true)}
+          onBlur={() => setIsInputFocus(false)}
         />
 
         {title.length > 0 && (

--- a/web/src/components/communityWrite/TitleForm.tsx
+++ b/web/src/components/communityWrite/TitleForm.tsx
@@ -36,6 +36,7 @@ export const TitleForm = ({ title, onChange }: TitleFormProps) => {
 
         {title.length > 0 && (
           <button
+            type="button"
             onClick={() => onChange("")}
             className="absolute top-1/2 right-4 h-[1.375rem] w-[1.375rem] -translate-y-1/2 rounded-full"
           >

--- a/web/src/components/communityWrite/TitleForm.tsx
+++ b/web/src/components/communityWrite/TitleForm.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent } from "react";
+import { useState, type ChangeEvent } from "react";
 
 import { cn } from "@/utils/cn";
 
@@ -10,7 +10,7 @@ interface TitleFormProps {
 }
 
 export const TitleForm = ({ title, onChange }: TitleFormProps) => {
-  const isInputFocus = title.length > 0;
+  const [isInputFocus, setIsInputFocus] = useState(false);
 
   return (
     <div>
@@ -32,6 +32,8 @@ export const TitleForm = ({ title, onChange }: TitleFormProps) => {
           onChange={(e: ChangeEvent<HTMLInputElement>) =>
             onChange(e.target.value)
           }
+          onFocus={() => setIsInputFocus(true)}
+          onBlur={() => setIsInputFocus(false)}
         />
 
         {title.length > 0 && (

--- a/web/src/components/communityWrite/TitleForm.tsx
+++ b/web/src/components/communityWrite/TitleForm.tsx
@@ -18,9 +18,9 @@ export const TitleForm = ({ title, onChange }: TitleFormProps) => {
         글 제목을 입력해주세요.
         <span className="text-primary-400">*</span>
       </h1>
-      <label htmlFor="nicknameInput" className="relative h-fit w-full">
+      <label htmlFor="titleInput" className="relative h-fit w-full">
         <input
-          id="nicknameInput"
+          id="titleInput"
           placeholder="최소 10자 이상 작성해주세요."
           className={cn(
             "body-3-regular w-full border-b p-3 overflow-ellipsis transition-colors outline-none",

--- a/web/src/hooks/useCommunityWriteState.ts
+++ b/web/src/hooks/useCommunityWriteState.ts
@@ -1,6 +1,9 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 
-import type { UploadedImage } from "@/types/communityWrite/communityWrite.types";
+import type {
+  UploadedImage,
+  CommunityWriteValidationError,
+} from "@/types/communityWrite/communityWrite.types";
 
 export const useCommunityWriteState = () => {
   const [form, setForm] = useState({
@@ -10,11 +13,40 @@ export const useCommunityWriteState = () => {
     images: [] as UploadedImage[],
   });
 
-  const MAX_IMAGE_SIZE = 5 * 1024 * 1024;
+  const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB입니다
 
-  const isImageTooLarge = form.images.some(
-    (img) => img.file.size > MAX_IMAGE_SIZE,
-  );
+  const validationErrors = useMemo<CommunityWriteValidationError>(() => {
+    const errors: CommunityWriteValidationError = {
+      titleTooShort: false,
+      contentTooShort: false,
+      boardEmpty: false,
+      imageTooLarge: false,
+    };
+
+    if (form.title.trim().length < 10) {
+      errors.titleTooShort = true;
+    }
+    if (form.content.trim().length < 10) {
+      errors.contentTooShort = true;
+    }
+    if (form.board.trim().length === 0) {
+      errors.boardEmpty = true;
+    }
+    if (form.images.some((img) => img.file.size > MAX_IMAGE_SIZE)) {
+      errors.imageTooLarge = true;
+    }
+
+    return errors;
+  }, [form, MAX_IMAGE_SIZE]);
+
+  const isValid = useMemo(() => {
+    return (
+      !validationErrors.titleTooShort &&
+      !validationErrors.contentTooShort &&
+      !validationErrors.boardEmpty &&
+      !validationErrors.imageTooLarge
+    );
+  }, [validationErrors]);
 
   const [toast, setToast] = useState({
     titleTooShort: false,
@@ -34,11 +66,6 @@ export const useCommunityWriteState = () => {
     setForm((prev) => ({ ...prev, [key]: value }));
   };
 
-  const isValid =
-    form.title.trim().length >= 10 &&
-    form.content.trim().length >= 10 &&
-    form.board.trim().length > 0;
-
   return {
     form,
     updateForm,
@@ -47,6 +74,6 @@ export const useCommunityWriteState = () => {
     modal,
     setModal,
     isValid,
-    isImageTooLarge,
+    validationErrors,
   };
 };

--- a/web/src/hooks/useCommunityWriteState.ts
+++ b/web/src/hooks/useCommunityWriteState.ts
@@ -1,0 +1,52 @@
+import { useState } from "react";
+
+import type { UploadedImage } from "@/types/communityWrite/communityWrite.types";
+
+export const useCommunityWriteState = () => {
+  const [form, setForm] = useState({
+    title: "",
+    board: "",
+    content: "",
+    images: [] as UploadedImage[],
+  });
+
+  const MAX_IMAGE_SIZE = 5 * 1024 * 1024;
+
+  const isImageTooLarge = form.images.some(
+    (img) => img.file.size > MAX_IMAGE_SIZE,
+  );
+
+  const [toast, setToast] = useState({
+    titleTooShort: false,
+    boardEmpty: false,
+    imageTooLarge: false,
+  });
+
+  const [modal, setModal] = useState({
+    leave: false,
+    complete: false,
+  });
+
+  const updateForm = <K extends keyof typeof form>(
+    key: K,
+    value: (typeof form)[K],
+  ) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const isValid =
+    form.title.trim().length >= 10 &&
+    form.content.trim().length >= 10 &&
+    form.board.trim().length > 0;
+
+  return {
+    form,
+    updateForm,
+    toast,
+    setToast,
+    modal,
+    setModal,
+    isValid,
+    isImageTooLarge,
+  };
+};

--- a/web/src/pages/communityWrite/CommunityWrite.tsx
+++ b/web/src/pages/communityWrite/CommunityWrite.tsx
@@ -1,3 +1,140 @@
+import { useNavigate } from "react-router-dom";
+
+import { useCommunityWriteState } from "@/hooks/useCommunityWriteState";
+
+import { AppHeader } from "@/components/common/AppHeader";
+import { BottomFullButton } from "@/components/common/BottomFullButton";
+import { ConfirmModal } from "@/components/common/ConfirmModal";
+import { Toast } from "@/components/common/Toast";
+import { CommunityWriteForm } from "@/components/communityWrite/CommunityWriteForm";
+import { PostBoardSelect } from "@/components/communityWrite/PostBoardSelect";
+import { PostImageUploader } from "@/components/communityWrite/PostImageUploader";
+import { TitleForm } from "@/components/communityWrite/TitleForm";
+
 export const CommunityWrite = () => {
-  return <div>CommunityWrite</div>;
+  const navigate = useNavigate();
+  const {
+    form,
+    updateForm,
+    toast,
+    setToast,
+    modal,
+    setModal,
+    isValid,
+    isImageTooLarge,
+  } = useCommunityWriteState();
+
+  const handleBack = () => {
+    const hasContent =
+      form.title || form.board || form.content || form.images.length > 0;
+    if (hasContent) {
+      setModal((prev) => ({ ...prev, leave: true }));
+    } else {
+      navigate(-1);
+    }
+  };
+
+  const handleSubmit = () => {
+    if (!isValid) {
+      if (isImageTooLarge) {
+        showToast("image");
+      } else if (
+        form.title.trim().length < 10 ||
+        form.content.trim().length < 10
+      ) {
+        showToast("title");
+      } else if (!form.board) {
+        showToast("board");
+      }
+      return;
+    }
+
+    setModal((prev) => ({ ...prev, complete: true }));
+  };
+
+  const showToast = (type: "title" | "content" | "board" | "image") => {
+    const toastState = {
+      titleTooShort: false,
+      boardEmpty: false,
+      imageTooLarge: false,
+    };
+
+    if (type === "title" || type === "content") toastState.titleTooShort = true;
+    if (type === "board") toastState.boardEmpty = true;
+    if (type === "image") toastState.imageTooLarge = true;
+
+    setToast(toastState);
+
+    setTimeout(() => {
+      setToast({
+        titleTooShort: false,
+        boardEmpty: false,
+        imageTooLarge: false,
+      });
+    }, 3000);
+  };
+
+  return (
+    <div className="bg-bg-100 flex h-screen flex-col">
+      <AppHeader onPrev={handleBack} title="글 작성하기" />
+      <div className="justify mx-5 mt-[4.6875rem] flex h-full flex-col justify-between">
+        <TitleForm
+          title={form.title}
+          onChange={(v) => updateForm("title", v)}
+        />
+        <PostBoardSelect
+          value={form.board}
+          onChange={(v) => updateForm("board", v)}
+        />
+        <CommunityWriteForm
+          value={form.content}
+          onChange={(v) => updateForm("content", v)}
+        />
+        <PostImageUploader
+          value={form.images}
+          onChange={(v) => updateForm("images", v)}
+        />
+
+        <BottomFullButton
+          state={true}
+          onClick={handleSubmit}
+          content="등록하기"
+        />
+        {toast.imageTooLarge && (
+          <Toast text="사진 용량이 너무 커요." position="write" />
+        )}
+        {toast.titleTooShort && (
+          <Toast text="최소 10자 이상 작성해주세요." position="write" />
+        )}
+        {toast.boardEmpty && (
+          <Toast text="게시판을 선택해주세요." position="write" />
+        )}
+
+        {modal.leave && (
+          <ConfirmModal
+            title="작성 중인 글이 저장되지 않았어요."
+            description={`이 페이지를 나가면 지금까지 작성한 내용이\n모두 사라집니다. 정말 나가시겠어요?`}
+            confirmText="이어쓰기"
+            cancelText="나가기"
+            onConfirm={() => setModal((prev) => ({ ...prev, leave: false }))}
+            onCancel={() => navigate(-1)}
+          />
+        )}
+
+        {modal.complete && (
+          <ConfirmModal
+            title="작성을 완료했어요!"
+            description="작성하신 글을 보러가시겠어요?"
+            confirmText="보러가기"
+            cancelText="취소"
+            onConfirm={() => {
+              // TODO: @tifsy 경로 수정
+              navigate("/community/my-post");
+            }}
+            onCancel={() => navigate("/home")}
+          />
+        )}
+      </div>
+    </div>
+  );
 };

--- a/web/src/pages/communityWrite/CommunityWrite.tsx
+++ b/web/src/pages/communityWrite/CommunityWrite.tsx
@@ -21,7 +21,7 @@ export const CommunityWrite = () => {
     modal,
     setModal,
     isValid,
-    isImageTooLarge,
+    validationErrors,
   } = useCommunityWriteState();
 
   const handleBack = () => {
@@ -36,42 +36,25 @@ export const CommunityWrite = () => {
 
   const handleSubmit = () => {
     if (!isValid) {
-      if (isImageTooLarge) {
-        showToast("image");
-      } else if (
-        form.title.trim().length < 10 ||
-        form.content.trim().length < 10
-      ) {
-        showToast("title");
-      } else if (!form.board) {
-        showToast("board");
-      }
+      const newToastState = {
+        titleTooShort:
+          validationErrors.titleTooShort || validationErrors.contentTooShort,
+        boardEmpty: validationErrors.boardEmpty,
+        imageTooLarge: validationErrors.imageTooLarge,
+      };
+      setToast(newToastState);
+
+      setTimeout(() => {
+        setToast({
+          titleTooShort: false,
+          boardEmpty: false,
+          imageTooLarge: false,
+        });
+      }, 3000);
       return;
     }
 
     setModal((prev) => ({ ...prev, complete: true }));
-  };
-
-  const showToast = (type: "title" | "content" | "board" | "image") => {
-    const toastState = {
-      titleTooShort: false,
-      boardEmpty: false,
-      imageTooLarge: false,
-    };
-
-    if (type === "title" || type === "content") toastState.titleTooShort = true;
-    if (type === "board") toastState.boardEmpty = true;
-    if (type === "image") toastState.imageTooLarge = true;
-
-    setToast(toastState);
-
-    setTimeout(() => {
-      setToast({
-        titleTooShort: false,
-        boardEmpty: false,
-        imageTooLarge: false,
-      });
-    }, 3000);
   };
 
   return (

--- a/web/src/pages/communityWrite/CommunityWrite.tsx
+++ b/web/src/pages/communityWrite/CommunityWrite.tsx
@@ -75,9 +75,9 @@ export const CommunityWrite = () => {
   };
 
   return (
-    <div className="bg-bg-100 flex h-screen flex-col">
+    <div className="bg-bg-100 flex h-screen flex-col pb-5">
       <AppHeader onPrev={handleBack} title="글 작성하기" />
-      <div className="justify mx-5 mt-[4.6875rem] flex h-full flex-col justify-between">
+      <div className="justify mx-5 mt-[4.6875rem] flex h-full flex-col gap-y-[1.5rem]">
         <TitleForm
           title={form.title}
           onChange={(v) => updateForm("title", v)}

--- a/web/src/types/communityWrite/communityWrite.types.ts
+++ b/web/src/types/communityWrite/communityWrite.types.ts
@@ -2,3 +2,10 @@ export interface UploadedImage {
   previewUrl: string;
   file: File;
 }
+
+export type CommunityWriteValidationError = {
+  titleTooShort: boolean;
+  contentTooShort: boolean;
+  boardEmpty: boolean;
+  imageTooLarge: boolean;
+};

--- a/web/src/types/communityWrite/communityWrite.types.ts
+++ b/web/src/types/communityWrite/communityWrite.types.ts
@@ -1,0 +1,4 @@
+export interface UploadedImage {
+  previewUrl: string;
+  file: File;
+}


### PR DESCRIPTION
## 개요

커뮤니티 글 작성 화면 UI를 구현합니다.
Resolves: #34 

## PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가

## 작업 내용
### 1. 커뮤니티 글 작성 UI 및 기능 구현
- 공통 컴포넌트들을 활용하여 제목, 내용, 게시판 선택, 이미지 업로드가 가능한 글 작성 폼을 구현했습니다. 
- 등록하기 버튼 클릭 시 유효성 검증 후, 작성 완료 모달이 출력됩니다.
- 페이지 이탈 시 확인 모달이 표시됩니다. 
- 최대 5장까지 이미지를 업로드 할 수 있으며, 미리보기를 지원합니다. 

### 2. 상태 관리 로직 분리
- `useCommunityWriteState.ts`에 글 작성 상태 관리 로직을 분리하였습니다.
- 입력값(form), 모달/토스트 상태, 유효성 결과를 custom hook으로 추출했습니다. 

### 3. 이미지 타입 정의
- 이미지 미리보기와 원본 파일을 함께 다루기 위해 `UploadedImage.ts` 로 타입을 분리했습니다. 

## 스크린샷
<img width="200" alt="image" src="https://github.com/user-attachments/assets/b8d71382-eafc-428a-914e-ba5c6ec64e73" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/9431ab88-fc4c-47ee-baa5-263546779d0c" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/d9e066a7-f458-4240-9a99-8fe19d35d0c1" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/437ca1c7-47d0-42ad-8fcf-42333fec4455" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/210d0a85-67d0-479c-b819-7d18a29c734f" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/6be83982-8ac9-40fa-bba3-7f6edab724ad" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/c0b291b5-e7b8-4666-8b3f-619b1abf6084" />


## 공유사항 to 리뷰어
- 토스트 유효성 검증 로직에서 zod를 사용할까요? 🤔
- 코드에 개선 사항이 있다면 알려주세요! 🙇🏻‍♀️

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
