### PR TITLE
[FIX]: AI 결과지 중복 상수 값 주석 처리 

### DIFF
--- a/web/src/constants/analyze/result/detailCards.ts
+++ b/web/src/constants/analyze/result/detailCards.ts
@@ -55,7 +55,7 @@ const INVESTMENT_DETAILS_TEXT = [
 ];
 
 export const DETAIL_CARD_CONTENT = {
-  URL_ANALYSIS: {
+  URL: {
     TEXTS: COMMON_URL_FISHING_DETAILS_TEXT,
     IMAGES: {
       SAFE: [safeFishing1, safeFishing2],
@@ -63,7 +63,7 @@ export const DETAIL_CARD_CONTENT = {
       DANGER: [dangerFishing1, dangerFishing2],
     },
   },
-  FISHING_FRAUD: {
+  PHISHING: {
     TEXTS: COMMON_URL_FISHING_DETAILS_TEXT,
     IMAGES: {
       SAFE: [safeFishing1, safeFishing2],
@@ -71,7 +71,7 @@ export const DETAIL_CARD_CONTENT = {
       DANGER: [dangerFishing1, dangerFishing2],
     },
   },
-  INVESTMENT_FRAUD: {
+  INVESTMENT: {
     TEXTS: INVESTMENT_DETAILS_TEXT,
     IMAGES: {
       SAFE: [safeInvest1, safeInvest2, safeInvest3],

--- a/web/src/constants/analyze/result/index.ts
+++ b/web/src/constants/analyze/result/index.ts
@@ -55,11 +55,12 @@ export const ALL_ANALYSIS_DATA: AllAnalysisData = {
     [ANALYSIS_STATUS.WARNING]: createAnalysisData("URL_ANALYSIS", "WARNING"),
     [ANALYSIS_STATUS.DANGER]: createAnalysisData("URL_ANALYSIS", "DANGER"),
   },
-  [ANALYSIS_CATEGORY.FISHING]: {
+  // 현재 서버에서 URL과 피싱 사례 분석을 같은 값을 주고 있어서 겹치는 오류가 나서 주석 처리하였습니다.
+  /*[ANALYSIS_CATEGORY.FISHING]: {
     [ANALYSIS_STATUS.SAFE]: createAnalysisData("FISHING_FRAUD", "SAFE"),
     [ANALYSIS_STATUS.WARNING]: createAnalysisData("FISHING_FRAUD", "WARNING"),
     [ANALYSIS_STATUS.DANGER]: createAnalysisData("FISHING_FRAUD", "DANGER"),
-  },
+  },*/
   [ANALYSIS_CATEGORY.INVESTMENT]: {
     [ANALYSIS_STATUS.SAFE]: createAnalysisData("INVESTMENT_FRAUD", "SAFE"),
     [ANALYSIS_STATUS.WARNING]: createAnalysisData(

--- a/web/src/constants/analyze/result/index.ts
+++ b/web/src/constants/analyze/result/index.ts
@@ -51,23 +51,20 @@ const createAnalysisData = (
 
 export const ALL_ANALYSIS_DATA: AllAnalysisData = {
   [ANALYSIS_CATEGORY.URL]: {
-    [ANALYSIS_STATUS.SAFE]: createAnalysisData("URL_ANALYSIS", "SAFE"),
-    [ANALYSIS_STATUS.WARNING]: createAnalysisData("URL_ANALYSIS", "WARNING"),
-    [ANALYSIS_STATUS.DANGER]: createAnalysisData("URL_ANALYSIS", "DANGER"),
+    [ANALYSIS_STATUS.SAFE]: createAnalysisData("URL", "SAFE"),
+    [ANALYSIS_STATUS.WARNING]: createAnalysisData("URL", "WARNING"),
+    [ANALYSIS_STATUS.DANGER]: createAnalysisData("URL", "DANGER"),
   },
   // 현재 서버에서 URL과 피싱 사례 분석을 같은 값을 주고 있어서 겹치는 오류가 나서 주석 처리하였습니다.
-  /*[ANALYSIS_CATEGORY.FISHING]: {
-    [ANALYSIS_STATUS.SAFE]: createAnalysisData("FISHING_FRAUD", "SAFE"),
-    [ANALYSIS_STATUS.WARNING]: createAnalysisData("FISHING_FRAUD", "WARNING"),
-    [ANALYSIS_STATUS.DANGER]: createAnalysisData("FISHING_FRAUD", "DANGER"),
+  /*[ANALYSIS_CATEGORY.PHISHING]: {
+    [ANALYSIS_STATUS.SAFE]: createAnalysisData("PHISHING", "SAFE"),
+    [ANALYSIS_STATUS.WARNING]: createAnalysisData("PHISHING", "WARNING"),
+    [ANALYSIS_STATUS.DANGER]: createAnalysisData("PHISHING", "DANGER"),
   },*/
   [ANALYSIS_CATEGORY.INVESTMENT]: {
-    [ANALYSIS_STATUS.SAFE]: createAnalysisData("INVESTMENT_FRAUD", "SAFE"),
-    [ANALYSIS_STATUS.WARNING]: createAnalysisData(
-      "INVESTMENT_FRAUD",
-      "WARNING",
-    ),
-    [ANALYSIS_STATUS.DANGER]: createAnalysisData("INVESTMENT_FRAUD", "DANGER"),
+    [ANALYSIS_STATUS.SAFE]: createAnalysisData("INVESTMENT", "SAFE"),
+    [ANALYSIS_STATUS.WARNING]: createAnalysisData("INVESTMENT", "WARNING"),
+    [ANALYSIS_STATUS.DANGER]: createAnalysisData("INVESTMENT", "DANGER"),
   },
 };
 


### PR DESCRIPTION
## 개요 

주석에 작성한 것처럼 현재 서버에서 URL과 사례 분석 중 피싱 사기는 같은 "PHISHING"이라는 그룹으로 주어 중복된 상수 값이 생겨 오류가 발생
-> 추후에 3가지로 나뉠 가능성이 있으니 주석 처리 

상수명 서버 응답값에 맞게 수정 