### PR TITLE
[FIX]: 커뮤니티 상세 페이지 배포 오류 수정

### DIFF
--- a/web/src/pages/communityDetail/CommunityDetail.tsx
+++ b/web/src/pages/communityDetail/CommunityDetail.tsx
@@ -14,7 +14,8 @@ export const CommunityDetail = () => {
 
   const post = mockCommunityFeedPreviews.find((item) => String(item.id) === id);
   if (!post) {
-    return console.log("‼️게시글 없음");
+    console.log("‼️게시글 없음");
+    return null;
   }
   const { title, nickname, date, content, images } = post;
 

--- a/web/src/pages/my/MyPostsPage.tsx
+++ b/web/src/pages/my/MyPostsPage.tsx
@@ -38,6 +38,7 @@ export const MyPostsPage = () => {
                 content={post.content}
                 commentCount={post.commentCount}
                 images={post.images}
+                category={post.category}
               />
             ))}
           </div>


### PR DESCRIPTION
## 개요

커뮤니티 상세 페이지 배포 오류를 수정했습니다. 
Resolves: #80 

## PR 유형

어떤 변경 사항이 있나요?

- [X] 버그 수정

## 작업 내용

### 1. 커뮤니티 상세 페이지 배포 오류 수정 
- 누락된 `category` 필드 추가로 CommunityPost 타입의 오류를 해결했습니다.
- 커뮤니티 게시글 상세 페이지에서 post 없을 경우, 콘솔에 에러만 출력했었는데, `null` 반환하도록 수정했습니다.

## 공유사항 to 리뷰어

- 간단한 배포 오류 수정입니다!

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
