### PR TITLE
[FEAT]: 검색 페이지 API 연동

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -18,6 +18,7 @@
         "prettier-plugin-tailwindcss": "^0.6.13",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-intersection-observer": "^9.16.0",
         "react-router-dom": "^7.6.2",
         "react-toastify": "^11.0.5",
         "tailwind-merge": "^3.3.1",
@@ -5633,6 +5634,20 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.16.0",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.16.0.tgz",
+      "integrity": "sha512-w9nJSEp+DrW9KmQmeWHQyfaP6b03v+TdXynaoA964Wxt7mdR3An11z4NNCQgL4gKSK7y1ver2Fq+JKH6CWEzUA==",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router": {

--- a/web/package.json
+++ b/web/package.json
@@ -20,6 +20,7 @@
     "prettier-plugin-tailwindcss": "^0.6.13",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-intersection-observer": "^9.16.0",
     "react-router-dom": "^7.6.2",
     "react-toastify": "^11.0.5",
     "tailwind-merge": "^3.3.1",

--- a/web/src/apis/community/getCommunityPosts.ts
+++ b/web/src/apis/community/getCommunityPosts.ts
@@ -1,0 +1,30 @@
+import { authAPI } from "@/apis/instance";
+import type { CommunityPost } from "@/types/community/community.types";
+
+import { API_DOMAINS } from "@/constants/apiConstants";
+
+interface CommunityPostsResponse {
+  content: CommunityPost[];
+  totalElements: number;
+  totalPages: number;
+  first: boolean;
+  last: boolean;
+  number: number;
+  size: number;
+}
+
+interface SearchParams {
+  keyword: string;
+  sort?: string;
+  page: number;
+  size: number;
+}
+
+export const getCommunityPosts = async (
+  params: SearchParams,
+): Promise<CommunityPostsResponse> => {
+  const response = await authAPI.get(API_DOMAINS.GET_COMMUNITY_POSTS, {
+    params,
+  });
+  return response.data;
+};

--- a/web/src/components/common/SearchBar.tsx
+++ b/web/src/components/common/SearchBar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import type { ChangeEvent, KeyboardEvent } from "react";
 
 import { useNavigate } from "react-router-dom";
 
@@ -12,12 +13,14 @@ interface SearchBarProps {
   placeholder: string;
   value: string;
   onChange: (value: string) => void;
+  onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
 }
 
 export const SearchBar = ({
   placeholder,
   value = "",
   onChange,
+  onKeyDown,
 }: SearchBarProps) => {
   const navigate = useNavigate();
 
@@ -41,7 +44,10 @@ export const SearchBar = ({
           type="text"
           placeholder={placeholder}
           value={value}
-          onChange={(e) => onChange(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            onChange(e.target.value)
+          }
+          onKeyDown={onKeyDown}
           className={cn(
             "caret-primary-400 placeholder-gray-system-600 w-full bg-transparent focus:outline-none",
             isSearchBarFilled

--- a/web/src/constants/apiConstants.ts
+++ b/web/src/constants/apiConstants.ts
@@ -10,6 +10,7 @@ export const API_DOMAINS = {
   GET_MYPAGE_COMMUNITY_POSTS_MANAGEMENT:
     "/v1/api/mypage/community/posts/management",
   GET_MYPAGE_DETECTION_HISTORY: "/v1/api/mypage/detection/history",
+  GET_COMMUNITY_POSTS: "v1/api/community/posts",
 };
 
 export const QUERY_KEYS = {

--- a/web/src/pages/searchPage/SearchPage.tsx
+++ b/web/src/pages/searchPage/SearchPage.tsx
@@ -5,6 +5,7 @@ import { useInView } from "react-intersection-observer";
 
 import { getCommunityPosts } from "@/apis/community/getCommunityPosts";
 
+import { LoadingSpinner } from "@/components/animation/LoadingSpinner";
 import { NoResult } from "@/components/common/NoResult";
 import { SearchBar } from "@/components/common/SearchBar";
 import { ToTop } from "@/components/common/ToTop";
@@ -81,8 +82,8 @@ export const SearchPage = () => {
                 ))}
               </ul>
               {hasNextPage && !isFetchingNextPage && (
-                <div ref={inViewRef} className="py-4 text-center">
-                  로딩 중...
+                <div ref={inViewRef} className="flex justify-center py-4">
+                  <LoadingSpinner width={16} height={16} />
                 </div>
               )}
             </>

--- a/web/src/pages/searchPage/SearchPage.tsx
+++ b/web/src/pages/searchPage/SearchPage.tsx
@@ -1,23 +1,56 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { useInView } from "react-intersection-observer";
+
+import { getCommunityPosts } from "@/apis/community/getCommunityPosts";
 
 import { NoResult } from "@/components/common/NoResult";
 import { SearchBar } from "@/components/common/SearchBar";
 import { ToTop } from "@/components/common/ToTop";
 import { SearchResultPreview } from "@/components/searchPage/SearchResultPreview";
 
-import { mockCommunityFeedPreviews } from "@/mocks/mockCommunityFeedPreviews";
 export const SearchPage = () => {
   const [query, setQuery] = useState("");
+  const [searchKeyword, setSearchKeyword] = useState("");
 
   const scrollRef = useRef<HTMLDivElement>(null);
+  const { ref: inViewRef, inView } = useInView();
 
-  const filteredPosts = mockCommunityFeedPreviews.filter(
-    (post) =>
-      post.title.toLowerCase().includes(query.toLowerCase()) ||
-      post.content.toLowerCase().includes(query.toLowerCase()),
-  );
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery({
+      queryKey: ["searchPosts", searchKeyword],
+      queryFn: ({ pageParam = 0 }) =>
+        getCommunityPosts({
+          keyword: searchKeyword,
+          sort: "latest",
+          page: pageParam,
+          size: 20,
+        }),
+      initialPageParam: 0,
+      getNextPageParam: (lastPage) => {
+        return lastPage.last ? undefined : lastPage.number + 1;
+      },
+      enabled: !!searchKeyword,
+    });
 
-  const hasNoSearchResult = query.trim() !== "" && filteredPosts.length === 0;
+  const allPosts = data?.pages.flatMap((page) => page.content) || [];
+
+  const handleSearch = () => {
+    setSearchKeyword(query);
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      handleSearch();
+    }
+  };
+
+  useEffect(() => {
+    if (inView && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   return (
     <div className="bg-bg-100 safearea flex h-screen flex-col">
@@ -26,25 +59,34 @@ export const SearchPage = () => {
           placeholder="사기 사례를 검색해주세요."
           value={query}
           onChange={setQuery}
+          onKeyDown={handleKeyPress}
         />
       </header>
 
-      <div className="overflow-y-auto px-5 pt-[4.25rem]">
-        {hasNoSearchResult ? (
-          <NoResult text="검색 결과를 찾을 수 없어요." type="none" />
-        ) : (
-          <ul>
-            {filteredPosts.map((post) => (
-              <li key={post.id}>
-                <SearchResultPreview
-                  id={post.id}
-                  title={post.title}
-                  content={post.content}
-                />
-              </li>
-            ))}
-          </ul>
-        )}
+      <div ref={scrollRef} className="overflow-y-auto px-5 pt-[4.25rem]">
+        {searchKeyword !== "" &&
+          (allPosts.length === 0 ? (
+            <NoResult text="검색 결과를 찾을 수 없어요." type="none" />
+          ) : (
+            <>
+              <ul>
+                {allPosts.map((post) => (
+                  <li key={post.id}>
+                    <SearchResultPreview
+                      id={post.id}
+                      title={post.title}
+                      content={post.content}
+                    />
+                  </li>
+                ))}
+              </ul>
+              {hasNextPage && !isFetchingNextPage && (
+                <div ref={inViewRef} className="py-4 text-center">
+                  로딩 중...
+                </div>
+              )}
+            </>
+          ))}
       </div>
 
       <ToTop bottom="2rem" scrollContainerRef={scrollRef} />

--- a/web/src/pages/searchPage/SearchPage.tsx
+++ b/web/src/pages/searchPage/SearchPage.tsx
@@ -38,7 +38,8 @@ export const SearchPage = () => {
   const allPosts = data?.pages.flatMap((page) => page.content) || [];
 
   const handleSearch = () => {
-    setSearchKeyword(query);
+    if (query.trim() === "") return;
+    setSearchKeyword(query.trim());
   };
 
   const handleKeyPress = (e: React.KeyboardEvent) => {

--- a/web/src/pages/searchPage/SearchPage.tsx
+++ b/web/src/pages/searchPage/SearchPage.tsx
@@ -20,14 +20,14 @@ export const SearchPage = () => {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteQuery({
       queryKey: ["searchPosts", searchKeyword],
-      queryFn: ({ pageParam = 0 }) =>
+      queryFn: ({ pageParam = 1 }) =>
         getCommunityPosts({
           keyword: searchKeyword,
           sort: "latest",
           page: pageParam,
           size: 20,
         }),
-      initialPageParam: 0,
+      initialPageParam: 1,
       getNextPageParam: (lastPage) => {
         return lastPage.last ? undefined : lastPage.number + 1;
       },


### PR DESCRIPTION
## 개요

검색 페이지의 api를 연동합니다
Resolves: #101 

## PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [X] 빌드 부분 혹은 패키지 매니저 수정

## 작업 내용

### 1. 검색 페이지 api 연동
- `react-intersection-observer` 을 이용해 무한 스크롤을 구현했습니다.
- 검색 페이지의 api를 연동했습니다. 검색 페이지에서는 최신순/인기순 탭이 없어 기본적으로 최신순인 `latest`로 정렬됩니다.

## 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->

## 공유사항 to 리뷰어

- 아마 마이페이지에서 무한 스크롤 구현 할 때 `react-intersection-observer` 를 사용하지 않고 버튼 형식으로 했던 것으로 기억하는데 그 부분은 기존 기획/디자인과 다르니 수정하겠습니다..! 

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
