### PR TITLE
[FEAT]: 온보딩 및 로그인 상태 관리 로직 구현 

### DIFF
--- a/native/app/_layout.tsx
+++ b/native/app/_layout.tsx
@@ -1,5 +1,7 @@
-import { Stack } from "expo-router";
+import { SplashScreen, Stack } from "expo-router";
 import { SafeAreaProvider } from "react-native-safe-area-context";
+
+SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
   return (

--- a/native/app/index.tsx
+++ b/native/app/index.tsx
@@ -12,6 +12,7 @@ import { createWebView } from "@webview-bridge/react-native";
 import { appBridge, appSchema } from "@/bridge";
 import { initializeKakaoSDK } from "@react-native-kakao/core";
 import { useInitialUrl } from "@/hooks/useInitialUrl";
+import { SplashScreen } from "expo-router";
 
 const { WebView } = createWebView({
   bridge: appBridge,
@@ -26,6 +27,10 @@ export default function WebViewScreen() {
   const KAKAO_NATIVE_APP_KEY = process.env.EXPO_PUBLIC_KAKAO_NATIVE_KEY || "";
 
   const { initialUrl, isLoading } = useInitialUrl(WEB_APP_URL);
+
+  const handleWebViewLoadEnd = () => {
+    SplashScreen.hideAsync();
+  };
 
   useEffect(() => {
     const initKakaoSDK = async () => {
@@ -99,6 +104,7 @@ export default function WebViewScreen() {
           onError={(e) => {
             console.error("WebView error:", e.nativeEvent);
           }}
+          onLoadEnd={handleWebViewLoadEnd}
         />
       </KeyboardAvoidingView>
     </View>
@@ -114,7 +120,7 @@ const styles = StyleSheet.create({
   },
   webview: {
     flex: 1,
-    backgroundColor: "transparent",
+    backgroundColor: "#161517",
   },
   center: {
     justifyContent: "center",

--- a/native/app/index.tsx
+++ b/native/app/index.tsx
@@ -5,11 +5,13 @@ import {
   KeyboardAvoidingView,
   Platform,
   View,
+  ActivityIndicator,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { createWebView } from "@webview-bridge/react-native";
 import { appBridge, appSchema } from "@/bridge";
 import { initializeKakaoSDK } from "@react-native-kakao/core";
+import { useInitialUrl } from "@/hooks/useInitialUrl";
 
 const { WebView } = createWebView({
   bridge: appBridge,
@@ -22,6 +24,8 @@ export default function WebViewScreen() {
 
   const WEB_APP_URL = process.env.EXPO_PUBLIC_WEB_URL || "";
   const KAKAO_NATIVE_APP_KEY = process.env.EXPO_PUBLIC_KAKAO_NATIVE_KEY || "";
+
+  const { initialUrl, isLoading } = useInitialUrl(WEB_APP_URL);
 
   useEffect(() => {
     const initKakaoSDK = async () => {
@@ -42,6 +46,14 @@ export default function WebViewScreen() {
     true; 
   `;
 
+  if (isLoading || !initialUrl) {
+    return (
+      <View style={[styles.container, styles.center]}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
   return (
     <View style={styles.container}>
       <StatusBar
@@ -55,7 +67,7 @@ export default function WebViewScreen() {
         keyboardVerticalOffset={insets.top}
       >
         <WebView
-          source={{ uri: WEB_APP_URL }}
+          source={{ uri: initialUrl }}
           style={styles.webview}
           injectedJavaScript={injectedJavaScript}
           // JavaScript 관련
@@ -97,5 +109,9 @@ const styles = StyleSheet.create({
   webview: {
     flex: 1,
     backgroundColor: "transparent",
+  },
+  center: {
+    justifyContent: "center",
+    alignItems: "center",
   },
 });

--- a/native/app/index.tsx
+++ b/native/app/index.tsx
@@ -48,8 +48,14 @@ export default function WebViewScreen() {
 
   if (isLoading || !initialUrl) {
     return (
-      <View style={[styles.container, styles.center]}>
-        <ActivityIndicator size="large" />
+      <View
+        style={[
+          styles.container,
+          styles.center,
+          { backgroundColor: "#161517" },
+        ]}
+      >
+        <ActivityIndicator size="large" color={"#fff"} />
       </View>
     );
   }

--- a/native/bridge/index.ts
+++ b/native/bridge/index.ts
@@ -15,17 +15,18 @@ import type {
 import { authStorage } from "@/services/authStorage";
 import { postReissue } from "@/apis/postReissue";
 import { Share } from "react-native";
+import { onboardingStorage } from "@/services/onboardingStorage";
 
 interface AppBridgeType extends Bridge {
   isLoggedIn: boolean;
   socialLogin: (type: SocialType) => Promise<BridgeLoginResult>;
   getAccessToken: () => Promise<{ accessToken: string | null }>;
-  getRefreshToken: () => Promise<{ refreshToken: string | null }>;
   refreshTokens: () => Promise<{ accessToken: string | null }>;
   shareUrl: (data: {
     url: string;
     message?: string;
   }) => Promise<{ success: boolean; message?: string }>;
+  completeOnboarding: () => Promise<void>;
 }
 
 export const appBridge = bridge<AppBridgeType>((store) => ({
@@ -69,11 +70,6 @@ export const appBridge = bridge<AppBridgeType>((store) => ({
     return { accessToken };
   },
 
-  getRefreshToken: async () => {
-    const refreshToken = await authStorage.getRefreshToken();
-    return { refreshToken };
-  },
-
   refreshTokens: async () => {
     try {
       const refreshToken = await authStorage.getRefreshToken();
@@ -107,6 +103,9 @@ export const appBridge = bridge<AppBridgeType>((store) => ({
       return { success: false, message: "공유에 실패했습니다." };
     }
   },
+  completeOnboarding: async () => {
+    await onboardingStorage.completeOnboarding();
+  },
 }));
 
 // 웹에서 보낸 데이터의 유효성 검사 스키마
@@ -115,9 +114,6 @@ export const appSchema = postMessageSchema({
     validate: (data) => z.enum(["kakao", "apple"]).parse(data),
   },
   getAccessToken: {
-    validate: () => z.object({}).parse({}),
-  },
-  getRefreshToken: {
     validate: () => z.object({}).parse({}),
   },
   refreshTokens: {
@@ -131,6 +127,9 @@ export const appSchema = postMessageSchema({
           message: z.string().optional(),
         })
         .parse(data),
+  },
+  completeOnboarding: {
+    validate: () => z.object({}).parse({}),
   },
 });
 

--- a/native/hooks/useInitialUrl.ts
+++ b/native/hooks/useInitialUrl.ts
@@ -1,8 +1,6 @@
 import { useState, useEffect } from "react";
-import * as SecureStore from "expo-secure-store";
 import { authStorage } from "@/services/authStorage";
-
-const ONBOARDING_KEY = "hasCompletedOnboarding";
+import { onboardingStorage } from "@/services/onboardingStorage";
 
 export const useInitialUrl = (webAppUrl: string) => {
   const [initialUrl, setInitialUrl] = useState<string | null>(null);
@@ -11,11 +9,10 @@ export const useInitialUrl = (webAppUrl: string) => {
   useEffect(() => {
     const determineInitialUrl = async () => {
       try {
-        const hasCompletedOnboarding = await SecureStore.getItemAsync(
-          ONBOARDING_KEY
-        );
+        const hasCompletedOnboarding =
+          await onboardingStorage.checkOnboardingStatus();
 
-        if (hasCompletedOnboarding !== "true") {
+        if (!hasCompletedOnboarding) {
           setInitialUrl(`${webAppUrl}`);
         } else {
           const refreshToken = await authStorage.getRefreshToken();

--- a/native/hooks/useInitialUrl.ts
+++ b/native/hooks/useInitialUrl.ts
@@ -1,0 +1,40 @@
+import { useState, useEffect } from "react";
+import * as SecureStore from "expo-secure-store";
+import { authStorage } from "@/services/authStorage";
+
+const ONBOARDING_KEY = "hasCompletedOnboarding";
+
+export const useInitialUrl = (webAppUrl: string) => {
+  const [initialUrl, setInitialUrl] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const determineInitialUrl = async () => {
+      try {
+        const hasCompletedOnboarding = await SecureStore.getItemAsync(
+          ONBOARDING_KEY
+        );
+
+        if (hasCompletedOnboarding !== "true") {
+          setInitialUrl(`${webAppUrl}`);
+        } else {
+          const refreshToken = await authStorage.getRefreshToken();
+          if (refreshToken) {
+            setInitialUrl(`${webAppUrl}/home`);
+          } else {
+            setInitialUrl(`${webAppUrl}/login`);
+          }
+        }
+      } catch {
+        // 오류 시, 온보딩 화면
+        setInitialUrl(`${webAppUrl}`);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    determineInitialUrl();
+  }, [webAppUrl]);
+
+  return { initialUrl, isLoading };
+};

--- a/native/services/onboardingStorage.ts
+++ b/native/services/onboardingStorage.ts
@@ -1,0 +1,23 @@
+import * as SecureStore from "expo-secure-store";
+
+const ONBOARDING_KEY = "hasCompletedOnboarding";
+
+export const onboardingStorage = {
+  async checkOnboardingStatus(): Promise<boolean> {
+    try {
+      const status = await SecureStore.getItemAsync(ONBOARDING_KEY);
+      return status === "true";
+    } catch (error) {
+      console.error("온보딩 상태 확인 실패:", error);
+      return false;
+    }
+  },
+
+  async completeOnboarding(): Promise<void> {
+    try {
+      await SecureStore.setItemAsync(ONBOARDING_KEY, "true");
+    } catch (error) {
+      console.error("온보딩 상태 저장 실패:", error);
+    }
+  },
+};

--- a/web/src/pages/onboarding/OnboardingPage.tsx
+++ b/web/src/pages/onboarding/OnboardingPage.tsx
@@ -6,6 +6,7 @@ import { AnimatePresence, motion } from "framer-motion";
 
 import { path } from "@/routes/path";
 
+import { bridge } from "@/bridge";
 import { useImagePreloader } from "@/hooks/useImagePreloader";
 
 import { LoadingSpinner } from "@/components/animation/LoadingSpinner";
@@ -33,6 +34,11 @@ export const OnboardingPage = () => {
     if (stepState >= ONBOARDING_TOTAL_STEP) return;
     setStepState((prev) => prev + 1);
   }, []);
+
+  const handleCompleteOnboarding = async () => {
+    await bridge.completeOnboarding();
+    navigate(path.auth.login);
+  };
 
   useEffect(() => {
     if (stepState >= ONBOARDING_TOTAL_STEP) {
@@ -90,8 +96,8 @@ export const OnboardingPage = () => {
       <div className="border-t-gray-system-800 w-full border-t px-5 py-3">
         <BottomFullButton
           content={"시작하기"}
-          state={stepState === 4}
-          onClick={() => navigate(path.auth.login)}
+          state={stepState === ONBOARDING_TOTAL_STEP}
+          onClick={handleCompleteOnboarding}
         />
       </div>
     </div>

--- a/web/src/types/bridge/bridge.types.ts
+++ b/web/src/types/bridge/bridge.types.ts
@@ -47,6 +47,7 @@ export interface NativeBridgeMethods {
     url: string;
     message?: string;
   }) => Promise<BridgeShareResult>;
+  completeOnboarding: () => Promise<void>;
 }
 
 export type AppBridgeSpec = AppState & NativeBridgeMethods;

--- a/web/src/types/bridge/bridge.types.ts
+++ b/web/src/types/bridge/bridge.types.ts
@@ -42,7 +42,6 @@ export interface AppState {
 export interface NativeBridgeMethods {
   socialLogin: (type: SocialType) => Promise<BridgeLoginResult>;
   getAccessToken: () => Promise<{ accessToken: string | null }>;
-  getRefreshToken: () => Promise<{ refreshToken: string | null }>;
   refreshTokens: () => Promise<{ accessToken: string | null }>;
   shareUrl: (data: {
     url: string;


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

 Resolves: #98 
 
사용자의 첫 앱 실행 경험을 개선하기 위해 온보딩 및 로그인 상태에 따른 초기 라우팅 로직을 구현했습니다. 이를 통해 신규 사용자는 온보딩으로, 기존 사용자는 로그인 또는 메인 화면으로 앱의 진입 흐름을 최적화했습니다.

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링

## 작업 내용

### 1. 초기 URL 결정 로직을 위한 useInitialUrl 커스텀 훅 추가

- 네이티브 앱 실행 시 expo-secure-store를 조회하여 사용자의 온보딩 완료 여부와 로그인(리프레시 토큰) 여부를 확인합니다.

- 사용자의 상태에 따라 웹뷰가 시작될 초기 URL(온보딩, 로그인, 홈)을 결정하는 로직을 훅으로 분리했습니다.

- URL 결정 전까지 로딩 상태를 관리하여 화면 깜빡임 현상을 방지합니다.

### 2. 웹뷰 브릿지(appBridge) 기능 추가 및 수정

- 웹뷰에서 온보딩 완료 시 네이티브에 상태를 저장하도록 요청하는 completeOnboarding 브릿지 함수를 추가했습니다.

- 관련 로직을 onboardingStorage 모듈로 분리하여 authStorage와 동일한 패턴으로 작성했습니다. 


## 공유사항 to 리뷰어

- 현재 앱 진입시 깜빡임을 최소화 하긴 했지만, 그래도 살짝 보이긴 하는 수준이라 추후에 고치면 될 것 같습니다 :) 

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
