### PR TITLE
[FEAT]: 커뮤니티 글 작성 이미지 api 연동 수정 및 마이페이지 게시글 삭제 연동 

### DIFF
--- a/web/src/apis/community/deletePost.ts
+++ b/web/src/apis/community/deletePost.ts
@@ -1,0 +1,12 @@
+import { generateApiPath } from "@/utils/generateApiPath";
+
+import { API_DOMAINS } from "@/constants/apiConstants";
+
+import { authAPI } from "../instance";
+
+export const deletePost = async ({ postId }: { postId: number }) => {
+  const response = await authAPI.delete(
+    generateApiPath(API_DOMAINS.DELETE_COMMUNITY_POST, { postId }),
+  );
+  return response.data;
+};

--- a/web/src/apis/community/postCommunity.ts
+++ b/web/src/apis/community/postCommunity.ts
@@ -9,8 +9,6 @@ interface UploadResponse {
 
 //커뮤니티 글 작성 api 요청
 interface CommunityPostRequest {
-  userId: number;
-  nickname: string;
   title: string;
   content: string;
   category: string;

--- a/web/src/apis/community/postCommunity.ts
+++ b/web/src/apis/community/postCommunity.ts
@@ -3,12 +3,12 @@ import { authAPI } from "@/apis/instance";
 import { API_DOMAINS } from "@/constants/apiConstants";
 
 //커뮤니티 글 작성 이미지 업로드 api 응답
-interface UploadResponse {
+export interface UploadResponse {
   fileUploadIds: number[];
 }
 
 //커뮤니티 글 작성 api 요청
-interface CommunityPostRequest {
+export interface CommunityPostRequest {
   title: string;
   content: string;
   category: string;
@@ -16,9 +16,7 @@ interface CommunityPostRequest {
 }
 
 //커뮤니티 글 작성 api 응답
-interface CommunityPostResponse {
-  postId: number;
-}
+export type CommunityPostResponse = number;
 
 export const postFilesUpload = async (
   files: File[],

--- a/web/src/apis/community/postCommunity.ts
+++ b/web/src/apis/community/postCommunity.ts
@@ -3,9 +3,18 @@ import { authAPI } from "@/apis/instance";
 import { API_DOMAINS } from "@/constants/apiConstants";
 
 //커뮤니티 글 작성 이미지 업로드 api 응답
-export interface UploadResponse {
-  fileUploadIds: number[];
+
+export interface UploadObject {
+  fileUploadId: number;
+  originalName: string;
+  s3Key: string;
+  size: number;
+  contentType: string;
+  isTemp: boolean;
+  createdAt: string;
 }
+
+export type UploadResponse = UploadObject[];
 
 //커뮤니티 글 작성 api 요청
 export interface CommunityPostRequest {

--- a/web/src/apis/community/postCommunityPosts.ts
+++ b/web/src/apis/community/postCommunityPosts.ts
@@ -1,9 +1,0 @@
-import { authAPI } from "@/apis/instance";
-import type { CommunityPost } from "@/types/community/community.types";
-
-import { API_DOMAINS } from "@/constants/apiConstants";
-
-export const postCommunityPosts = async (): Promise<CommunityPost> => {
-  const response = await authAPI.post(API_DOMAINS.POST_COMMUNITY_POSTS);
-  return response.data;
-};

--- a/web/src/components/my/MyPostsPreview.tsx
+++ b/web/src/components/my/MyPostsPreview.tsx
@@ -1,5 +1,10 @@
 import { useState } from "react";
 
+import { useNavigate } from "react-router-dom";
+
+import { path } from "@/routes/path";
+
+import { useDeletePostMutation } from "@/hooks/mutations/useDeletePostMutation";
 import type { CommunityPost } from "@/types/community/community.types";
 import { cn } from "@/utils/cn";
 
@@ -20,9 +25,15 @@ export const MyPostsPreview = ({
   commentCount,
   images = [],
 }: CommunityPost) => {
+  const navigate = useNavigate();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
-  const handleRemoveClick = () => {
+  const { mutate: deletePostMutation } = useDeletePostMutation(() =>
+    setIsDeleteModalOpen(false),
+  );
+
+  const handleRemoveClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
     setIsDeleteModalOpen(true);
   };
 
@@ -31,12 +42,14 @@ export const MyPostsPreview = ({
   };
 
   const handleDeletePost = () => {
-    console.log("🗑️게시글 삭제");
-    setIsDeleteModalOpen(false);
+    deletePostMutation({ postId: id });
   };
 
   return (
-    <div className="text-gray-system-600 space-y-2 py-3">
+    <div
+      onClick={() => navigate(path.community.detail(String(id)))}
+      className="text-gray-system-600 space-y-2 py-3"
+    >
       <div className="flex items-start justify-between">
         <div className="flex gap-3">
           {/* TODO: @tifsy 사용자 프로필 사진 불러오기 */}

--- a/web/src/constants/apiConstants.ts
+++ b/web/src/constants/apiConstants.ts
@@ -11,9 +11,10 @@ export const API_DOMAINS = {
   GET_MYPAGE_COMMUNITY_POSTS_MANAGEMENT:
     "/v1/api/mypage/community/posts/management",
   GET_MYPAGE_DETECTION_HISTORY: "/v1/api/mypage/detection/history",
-  GET_COMMUNITY_POSTS: "v1/api/community/posts",
-  POST_COMMUNITY_POSTS: "v1/api/community/posts",
-  POST_FILES_UPLOAD: "v1/api/files/upload",
+  GET_COMMUNITY_POSTS: "/v1/api/community/posts",
+  POST_COMMUNITY_POSTS: "/v1/api/community/posts",
+  POST_FILES_UPLOAD: "/v1/api/files/upload",
+  DELETE_COMMUNITY_POST: "/v1/api/community/posts/:postId",
 };
 
 export const QUERY_KEYS = {

--- a/web/src/constants/commnityFeedTabs.ts
+++ b/web/src/constants/commnityFeedTabs.ts
@@ -1,1 +1,7 @@
 export const COMMUNITY_FEED_TABS = ["신고합니다", "내 사례 공유", "자유 TALK"];
+
+export const BOARD_CATEGORY_MAP: Record<string, string> = {
+  신고합니다: "REPORT",
+  "내 사례 공유": "SHARE",
+  "자유 TALK": "TALK",
+};

--- a/web/src/hooks/mutations/useDeletePostMutation.ts
+++ b/web/src/hooks/mutations/useDeletePostMutation.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { deletePost } from "@/apis/community/deletePost";
+
+import { QUERY_KEYS } from "@/constants/apiConstants";
+
+export const useDeletePostMutation = (onSuccessCallback?: () => void) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deletePost,
+    // 케이스 별로 다르게 쿼리 클라이언트 초기화 시킬 예정
+    onSuccess: () => {
+      if (onSuccessCallback) {
+        onSuccessCallback();
+      }
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.MYPAGE_POST] });
+    },
+    // 추후, 토스트 구현?
+    onError: (error) => {
+      console.error("게시글 삭제 실패:", error);
+    },
+  });
+};

--- a/web/src/pages/communityWrite/CommunityWrite.tsx
+++ b/web/src/pages/communityWrite/CommunityWrite.tsx
@@ -2,11 +2,15 @@ import { useState } from "react";
 
 import { useNavigate } from "react-router-dom";
 
+import { useMutation } from "@tanstack/react-query";
+
 import {
   postCommunityPosts,
   postFilesUpload,
+  type CommunityPostResponse,
 } from "@/apis/community/postCommunity";
 import { useCommunityWriteState } from "@/hooks/useCommunityWriteState";
+import type { CommunityWriteFormState } from "@/types/community/community.types";
 
 import { AppHeader } from "@/components/common/AppHeader";
 import { BottomFullButton } from "@/components/common/BottomFullButton";
@@ -16,6 +20,8 @@ import { CommunityWriteForm } from "@/components/communityWrite/CommunityWriteFo
 import { PostBoardSelect } from "@/components/communityWrite/PostBoardSelect";
 import { PostImageUploader } from "@/components/communityWrite/PostImageUploader";
 import { TitleForm } from "@/components/communityWrite/TitleForm";
+
+import { BOARD_CATEGORY_MAP } from "@/constants/commnityFeedTabs";
 
 export const CommunityWrite = () => {
   const navigate = useNavigate();
@@ -31,6 +37,39 @@ export const CommunityWrite = () => {
     toastMessage,
     showToast,
   } = useCommunityWriteState();
+
+  const { mutate: createPost, isPending: isPosting } = useMutation<
+    CommunityPostResponse,
+    Error,
+    CommunityWriteFormState
+  >({
+    mutationFn: async (formData) => {
+      let fileUploadIds: number[] = [];
+      if (formData.images.length > 0) {
+        const files = formData.images.map((img) => img.file);
+        const uploadResponse = await postFilesUpload(files);
+        fileUploadIds = uploadResponse.fileUploadIds;
+      }
+      const categoryForApi =
+        BOARD_CATEGORY_MAP[formData.board] || formData.board;
+
+      const postData = {
+        title: formData.title,
+        content: formData.content,
+        category: categoryForApi,
+        fileUploadIds,
+      };
+      return postCommunityPosts(postData);
+    },
+    onSuccess: (response) => {
+      setLastPostedId(response);
+      setModal((prev) => ({ ...prev, complete: true }));
+    },
+    onError: (error) => {
+      showToast("글 작성에 실패했습니다. 다시 시도해주세요.");
+      console.error("❌글 작성 에러:", error);
+    },
+  });
 
   const handleBack = () => {
     const hasContent =
@@ -50,31 +89,7 @@ export const CommunityWrite = () => {
       }
       return;
     }
-
-    try {
-      let fileUploadIds: number[] = [];
-
-      if (form.images.length > 0) {
-        const files = form.images.map((img) => img.file);
-        const uploadResponse = await postFilesUpload(files);
-        fileUploadIds = uploadResponse.fileUploadIds;
-      }
-
-      const postData = {
-        title: form.title,
-        content: form.content,
-        category: form.board,
-        fileUploadIds,
-      };
-
-      const response = await postCommunityPosts(postData);
-      setLastPostedId(response.postId);
-      setModal((prev) => ({ ...prev, complete: true }));
-    } catch (error) {
-      showToast("글 작성에 실패했습니다. 다시 시도해주세요.");
-
-      console.error("❌글 작성 에러:", error);
-    }
+    createPost(form);
   };
 
   return (
@@ -106,9 +121,9 @@ export const CommunityWrite = () => {
         />
 
         <BottomFullButton
-          state={true}
+          state={!isPosting}
           onClick={handleSubmit}
-          content="등록하기"
+          content={isPosting ? "등록 중..." : "등록하기"}
         />
 
         {toastMessage && <Toast text={toastMessage} position="write" />}

--- a/web/src/pages/communityWrite/CommunityWrite.tsx
+++ b/web/src/pages/communityWrite/CommunityWrite.tsx
@@ -61,9 +61,6 @@ export const CommunityWrite = () => {
       }
 
       const postData = {
-        //하드코딩 된 유저 정보 가져와야 합니다!
-        userId: 1,
-        nickname: "글렌",
         title: form.title,
         content: form.content,
         category: form.board,

--- a/web/src/pages/communityWrite/CommunityWrite.tsx
+++ b/web/src/pages/communityWrite/CommunityWrite.tsx
@@ -48,7 +48,9 @@ export const CommunityWrite = () => {
       if (formData.images.length > 0) {
         const files = formData.images.map((img) => img.file);
         const uploadResponse = await postFilesUpload(files);
-        fileUploadIds = uploadResponse.fileUploadIds;
+        fileUploadIds = uploadResponse.map(
+          (responseItem) => responseItem.fileUploadId,
+        );
       }
       const categoryForApi =
         BOARD_CATEGORY_MAP[formData.board] || formData.board;

--- a/web/src/types/community/community.types.ts
+++ b/web/src/types/community/community.types.ts
@@ -26,6 +26,13 @@ export interface UploadedImage {
   file: File;
 }
 
+export interface CommunityWriteFormState {
+  title: string;
+  board: string;
+  content: string;
+  images: UploadedImage[];
+}
+
 //커뮤니티 글 작성 유효성
 export type CommunityWriteValidationError = {
   titleTooShort: boolean;


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

Resolves: #109 
커뮤니티 글 작성 이미지 api 연동 수정 및 마이페이지 게시글 삭제 연동 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링

## 작업 내용

### 1. 커뮤니티 글 작성 이미지 api 연동 수정 
- 서버 스웨거 변경에 따른 글 작성 이미지 api 수정
- 업로드 useMutation으로 변경 
- 글 작성 카테고리 상수 변경 
- 세부 글 작성 api 타입 변경 
<!-- 작업 사항에 대한 설명을 적어주세요 -->

### 2. 마이페이지 게시글 삭제 연동 
- 마이페이지 내 게시글 삭제 연동 
- 이벤트 버블링 방지 


## 공유사항 to 리뷰어

- 커뮤니티 글 작성 및 마이페이지 게시글 삭제 확인하였습니다 :) 

<!-- 리뷰어가 중점적으로 봐주었으면 좋겠는 부분을 적어주세요 -->
<!-- 논의할 사항이 있다면 적어주세요 -->

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
