### PR TITLE
[FEAT]: 커뮤니티 피드 api 연동 및 소규모 리팩토링 + 검색창 디바운싱 적용 

### DIFF
--- a/web/src/apis/community/getCommunityPosts.ts
+++ b/web/src/apis/community/getCommunityPosts.ts
@@ -13,8 +13,18 @@ interface CommunityPostsResponse {
   size: number;
 }
 
+export interface PostItem {
+  id: number;
+  title: string;
+  authorNickname: string;
+  createdAt: string;
+  commentCount: number;
+  thumbnailUrls: string[];
+}
+
 interface SearchParams {
   keyword: string;
+  category?: string;
   sort?: string;
   page: number;
   size: number;
@@ -26,5 +36,6 @@ export const getCommunityPosts = async (
   const response = await authAPI.get(API_DOMAINS.GET_COMMUNITY_POSTS, {
     params,
   });
+  console.log(response);
   return response.data;
 };

--- a/web/src/apis/community/postBlock.ts
+++ b/web/src/apis/community/postBlock.ts
@@ -1,0 +1,13 @@
+import { authAPI } from "@/apis/instance";
+import { generateApiPath } from "@/utils/generateApiPath";
+
+import { API_DOMAINS } from "@/constants/apiConstants";
+
+export const postBlock = async ({ postId }: { postId: number }) => {
+  const response = await authAPI.post(
+    generateApiPath(API_DOMAINS.POST_BLOCK, { postId }),
+    { reason: "HATE" },
+  );
+  console.log(response);
+  return response.data;
+};

--- a/web/src/apis/community/postReport.ts
+++ b/web/src/apis/community/postReport.ts
@@ -1,0 +1,19 @@
+import { authAPI } from "@/apis/instance";
+import { generateApiPath } from "@/utils/generateApiPath";
+
+import { API_DOMAINS } from "@/constants/apiConstants";
+import type { ReportType } from "@/constants/reportReasons";
+
+export const postReport = async ({
+  reasonCode,
+  postId,
+}: {
+  reasonCode: ReportType;
+  postId: number;
+}) => {
+  const response = await authAPI.post(
+    generateApiPath(API_DOMAINS.POST_REPORT, { postId }),
+    { reasonCode },
+  );
+  return response.data;
+};

--- a/web/src/components/common/PostMenuButton.tsx
+++ b/web/src/components/common/PostMenuButton.tsx
@@ -1,70 +1,20 @@
-import { useState } from "react";
-
-import { BottomSheet } from "@/components/common/BottomSheet";
-import { ConfirmModal } from "@/components/common/ConfirmModal";
-import { ReportPostSheet } from "@/components/common/ReportPostSheet";
-import { SelectBox } from "@/components/common/SelectBox";
-
 import CommunityPostMenuIcon from "@/assets/icons/community_post_menu.svg?react";
 
-type ViewState = "closed" | "menu" | "block" | "report" | "reportComplete";
+interface PostMenuButtonProps {
+  postId: number;
+  onOpenMenu: (postId: number) => void;
+}
 
-export const PostMenuButton = () => {
-  const [viewState, setViewState] = useState<ViewState>("closed");
-
+export const PostMenuButton = ({ postId, onOpenMenu }: PostMenuButtonProps) => {
   return (
-    <>
-      <button
-        aria-label="커뮤니티 글 메뉴 열기"
-        onClick={() => setViewState("menu")}
-      >
-        <CommunityPostMenuIcon className="text-gray-system-500 h-6 w-6" />
-      </button>
-
-      <BottomSheet
-        isOpen={viewState === "menu"}
-        onClose={() => setViewState("closed")}
-      >
-        <div className="mx-5 my-[1.875rem] flex flex-col gap-2.5">
-          <SelectBox
-            type="postMenu"
-            label="해당 유저 차단하기"
-            onClick={() => setViewState("block")}
-          />
-          <SelectBox
-            type="postMenu"
-            label="신고하기"
-            onClick={() => setViewState("report")}
-          />
-        </div>
-      </BottomSheet>
-
-      {viewState === "block" && (
-        <ConfirmModal
-          title="해당 유저를 차단하시겠어요?"
-          description={`차단 시, 이 유저의 게시물을\n더 이상 볼 수 없습니다.`}
-          confirmText="차단하기"
-          cancelText="취소"
-          onConfirm={() => {
-            console.log("✅유저 차단 완료");
-            setViewState("closed");
-          }}
-          onCancel={() => setViewState("closed")}
-        />
-      )}
-
-      {viewState === "reportComplete" && (
-        <ConfirmModal
-          title="신고가 정상적으로 접수되었습니다."
-          description={`접수해주신 내용을 바탕으로\n신속하고 정확하게 검토하겠습니다.`}
-          onConfirm={() => setViewState("closed")}
-        />
-      )}
-      <ReportPostSheet
-        isOpen={viewState === "report"}
-        onClose={() => setViewState("closed")}
-        onReportComplete={() => setViewState("reportComplete")}
-      />
-    </>
+    <button
+      aria-label="커뮤니티 글 메뉴 열기"
+      onClick={(e: React.MouseEvent) => {
+        e.stopPropagation();
+        onOpenMenu(postId);
+      }}
+    >
+      <CommunityPostMenuIcon className="text-gray-system-500 h-6 w-6" />
+    </button>
   );
 };

--- a/web/src/components/common/ReportPostSheet.tsx
+++ b/web/src/components/common/ReportPostSheet.tsx
@@ -1,23 +1,43 @@
 import { useState, useEffect } from "react";
 
+import { useReportPostMutation } from "@/hooks/mutations/useReportPostMutation";
+
 import { BottomFullButton } from "@/components/common/BottomFullButton";
 import { BottomSheet } from "@/components/common/BottomSheet";
 import { SelectBox } from "@/components/common/SelectBox";
 
-import { REPORT_REASONS } from "@/constants/reportReasons";
+import { QUERY_KEYS } from "@/constants/apiConstants";
+import {
+  REPORT_REASON_MAP,
+  REPORT_REASONS,
+  type ReportType,
+} from "@/constants/reportReasons";
 
 interface ReportPostSheetProps {
+  postId: number;
   isOpen: boolean;
   onClose: () => void;
   onReportComplete: () => void;
 }
 
 export const ReportPostSheet = ({
+  postId,
   isOpen,
   onClose,
   onReportComplete,
 }: ReportPostSheetProps) => {
   const [selectedReason, setSelectedReason] = useState<string | null>(null);
+
+  // TODO: 카테고리 Props로 받아서 초기화 시키기
+  const { mutate: postReport, isPending: isReporting } = useReportPostMutation({
+    queryKeyToInvalidate: [QUERY_KEYS.GET_COMMUNITY_FEED],
+    onSuccess: () => {
+      onClose();
+      setTimeout(() => {
+        onReportComplete();
+      }, 100);
+    },
+  });
 
   const handleSelect = (reason: string) => {
     setSelectedReason((prev) => (prev === reason ? null : reason));
@@ -25,11 +45,14 @@ export const ReportPostSheet = ({
 
   const handleReport = () => {
     if (selectedReason) {
-      console.log("🚨신고 사유:", selectedReason);
-      onClose();
-      setTimeout(() => {
-        onReportComplete();
-      }, 100);
+      const reasonCode = REPORT_REASON_MAP[selectedReason] as ReportType;
+      if (!reasonCode) {
+        // TODO: 에러 디자인 나오면 변경
+        alert("유효하지 않은 신고 사유입니다.");
+        return;
+      }
+
+      postReport({ postId, reasonCode });
     }
   };
 
@@ -64,9 +87,9 @@ export const ReportPostSheet = ({
             />
           ))}
           <BottomFullButton
-            state={!!selectedReason}
+            state={!!selectedReason || isReporting}
             onClick={handleReport}
-            content="신고하기"
+            content={isReporting ? "신고 중.." : "신고하기"}
             className="mt-5"
           />
         </div>

--- a/web/src/components/common/SearchBar.tsx
+++ b/web/src/components/common/SearchBar.tsx
@@ -13,7 +13,7 @@ interface SearchBarProps {
   placeholder: string;
   value: string;
   onChange: (value: string) => void;
-  onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
+  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
 }
 
 export const SearchBar = ({

--- a/web/src/components/communityFeed/CommunityPostPreview.tsx
+++ b/web/src/components/communityFeed/CommunityPostPreview.tsx
@@ -1,30 +1,38 @@
 import { useNavigate } from "react-router-dom";
 
+import { path } from "@/routes/path";
+
 import type { CommunityPost } from "@/types/community/community.types";
 import { cn } from "@/utils/cn";
+import { formatUTCtoKR } from "@/utils/formatUTCtoKR";
 
 import { NameTag } from "@/components/common/NameTag";
 import { PostMenuButton } from "@/components/common/PostMenuButton";
 
-import CommentIcon from "@/assets/icons/comment.svg?react";
+//import CommentIcon from "@/assets/icons/comment.svg?react";
 //TODO: @tifsy 임시 프로필 이미지 제거
 import TemporaryProfilePicIcon from "@/assets/icons/temporary_profile_pic.svg";
 
+interface CommunityPostPreviewProps extends CommunityPost {
+  onOpenMenu: (postId: number) => void;
+}
+
 export const CommunityPostPreview = ({
   id,
-  nickname,
-  date,
+  onOpenMenu,
+  authorNickname,
+  createdAt,
   title,
   content,
-  commentCount,
-  images = [],
-}: CommunityPost) => {
+  //commentCount,
+  thumbnailUrls = [],
+}: CommunityPostPreviewProps) => {
   const navigate = useNavigate();
 
   return (
     <div
       className="text-gray-system-600 space-y-2 py-3"
-      onClick={() => navigate(`/community/${id}`)}
+      onClick={() => navigate(path.community.detail(String(id)))}
     >
       <div className="flex items-start justify-between">
         <div className="flex gap-3">
@@ -35,12 +43,18 @@ export const CommunityPostPreview = ({
             className="h-15 w-15 rounded-full"
           />
           <div className="flex flex-col gap-y-2.5">
-            <NameTag name={nickname} type="community_mono" className="h-7" />
-            <span className="text-gray-system-600 body-5-regular">{date}</span>
+            <NameTag
+              name={authorNickname}
+              type="community_mono"
+              className="h-7"
+            />
+            <span className="text-gray-system-600 body-5-regular">
+              {formatUTCtoKR(createdAt)}
+            </span>
           </div>
         </div>
 
-        <PostMenuButton />
+        <PostMenuButton postId={id} onOpenMenu={onOpenMenu} />
       </div>
 
       <div className="text-gray-system-100 body-1-bold">{title}</div>
@@ -49,34 +63,35 @@ export const CommunityPostPreview = ({
         {content}
       </p>
 
-      {images.length > 0 && (
+      {thumbnailUrls.length > 0 && (
         <div
           className={cn(
             "flex gap-[0.4375rem]",
-            images.length >= 3 && "scrollbar-hide overflow-x-auto",
+            thumbnailUrls.length >= 3 && "scrollbar-hide overflow-x-auto",
           )}
         >
-          {images
-            .slice(0, images.length >= 3 ? images.length : 2)
+          {thumbnailUrls
+            .slice(0, thumbnailUrls.length >= 3 ? thumbnailUrls.length : 2)
             .map((img, i) => (
               <img
                 key={`${img}-${i}`}
                 src={img}
                 alt={`게시글 이미지 ${i + 1}`}
                 className={cn("h-[6.875rem] rounded-lg object-cover", {
-                  "w-full": images.length === 1,
-                  "w-1/2": images.length === 2,
-                  "w-[8.125rem] flex-shrink-0": images.length >= 3,
+                  "w-full": thumbnailUrls.length === 1,
+                  "w-1/2": thumbnailUrls.length === 2,
+                  "w-[8.125rem] flex-shrink-0": thumbnailUrls.length >= 3,
                 })}
               />
             ))}
         </div>
       )}
-
+      {/** TODO: @Tifsy 2차 배포시, 댓글 추가 
       <div className="text-gray-system-500 body-5-regular flex items-center justify-end gap-1 pt-1">
         <span>{commentCount}</span>
         <CommentIcon className="h-5 w-5" />
       </div>
+       */}
     </div>
   );
 };

--- a/web/src/components/my/MyPostsPreview.tsx
+++ b/web/src/components/my/MyPostsPreview.tsx
@@ -7,30 +7,40 @@ import { path } from "@/routes/path";
 import { useDeletePostMutation } from "@/hooks/mutations/useDeletePostMutation";
 import type { CommunityPost } from "@/types/community/community.types";
 import { cn } from "@/utils/cn";
+import { formatUTCtoKR } from "@/utils/formatUTCtoKR";
 
 import { DeleteModal } from "@/components/common/DeleteModal";
 import { NameTag } from "@/components/common/NameTag";
 
-import CommentIcon from "@/assets/icons/comment.svg?react";
+//import CommentIcon from "@/assets/icons/comment.svg?react";
 //TODO: @tifsy 임시 프로필 이미지 제거
+import { QUERY_KEYS } from "@/constants/apiConstants";
+
 import RemoveIcon from "@/assets/icons/remove.svg?react";
 import TemporaryProfilePicIcon from "@/assets/icons/temporary_profile_pic.svg";
 
+interface MyPostsPreviewProps extends CommunityPost {
+  onDeleteSuccess: () => void;
+}
+
 export const MyPostsPreview = ({
   id,
-  nickname,
-  date,
+  onDeleteSuccess,
+
+  authorNickname,
+  createdAt,
   title,
   content,
-  commentCount,
-  images = [],
-}: CommunityPost) => {
+  //commentCount,
+  thumbnailUrls = [],
+}: MyPostsPreviewProps) => {
   const navigate = useNavigate();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
-  const { mutate: deletePostMutation } = useDeletePostMutation(() =>
-    setIsDeleteModalOpen(false),
-  );
+  const { mutate: deletePostMutation } = useDeletePostMutation({
+    queryKeyToInvalidate: [QUERY_KEYS.MYPAGE_POST],
+    onSuccess: onDeleteSuccess,
+  });
 
   const handleRemoveClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -58,9 +68,15 @@ export const MyPostsPreview = ({
             alt="임시 프로필 사진"
             className="h-15 w-15 rounded-full"
           />
-          <div className="flex flex-col gap-y-[10px]">
-            <NameTag name={nickname} type="community_mono" className="h-7" />
-            <span className="text-gray-system-600 body-5-regular">{date}</span>
+          <div className="flex flex-col gap-y-2.5">
+            <NameTag
+              name={authorNickname}
+              type="community_mono"
+              className="h-7"
+            />
+            <span className="text-gray-system-600 body-5-regular">
+              {formatUTCtoKR(createdAt)}
+            </span>
           </div>
         </div>
         <RemoveIcon onClick={handleRemoveClick} />
@@ -72,35 +88,35 @@ export const MyPostsPreview = ({
         {content}
       </p>
 
-      {images.length > 0 && (
+      {thumbnailUrls.length > 0 && (
         <div
           className={cn(
             "flex gap-[0.4375rem]",
-            images.length >= 3 && "scrollbar-hide overflow-x-auto",
+            thumbnailUrls.length >= 3 && "scrollbar-hide overflow-x-auto",
           )}
         >
-          {images
-            .slice(0, images.length >= 3 ? images.length : 2)
+          {thumbnailUrls
+            .slice(0, thumbnailUrls.length >= 3 ? thumbnailUrls.length : 2)
             .map((img, i) => (
               <img
                 key={`${img}-${i}`}
                 src={img}
                 alt={`게시글 이미지 ${i + 1}`}
                 className={cn("h-[6.875rem] rounded-lg object-cover", {
-                  "w-full": images.length === 1,
-                  "w-1/2": images.length === 2,
-                  "w-[8.125rem] flex-shrink-0": images.length >= 3,
+                  "w-full": thumbnailUrls.length === 1,
+                  "w-1/2": thumbnailUrls.length === 2,
+                  "w-[8.125rem] flex-shrink-0": thumbnailUrls.length >= 3,
                 })}
               />
             ))}
         </div>
       )}
-
+      {/** TODO: @Tifsy 2차 배포시, 댓글 추가 
       <div className="text-gray-system-500 body-5-regular flex items-center justify-end gap-1 pt-1">
         <span>{commentCount}</span>
         <CommentIcon className="h-5 w-5" />
       </div>
-
+      */}
       {isDeleteModalOpen && (
         <DeleteModal
           onCancel={handleCloseModal}

--- a/web/src/constants/apiConstants.ts
+++ b/web/src/constants/apiConstants.ts
@@ -26,4 +26,5 @@ export const QUERY_KEYS = {
   MYPAGE_POST: "myPagePosts",
   GET_DETECTION_RESULT: "myDetectionResult",
   GET_COMMUNITY_FEED: "communityPosts",
+  GET_SEARCH_RESULT: "searchResult",
 };

--- a/web/src/constants/apiConstants.ts
+++ b/web/src/constants/apiConstants.ts
@@ -15,6 +15,8 @@ export const API_DOMAINS = {
   POST_COMMUNITY_POSTS: "/v1/api/community/posts",
   POST_FILES_UPLOAD: "/v1/api/files/upload",
   DELETE_COMMUNITY_POST: "/v1/api/community/posts/:postId",
+  POST_REPORT: "/v1/api/community/posts/:postId/report",
+  POST_BLOCK: "/v1/api/community/posts/:postId/author/block",
 };
 
 export const QUERY_KEYS = {
@@ -23,4 +25,5 @@ export const QUERY_KEYS = {
   MYPAGE_DASHBOARD: "myPageDashboard",
   MYPAGE_POST: "myPagePosts",
   GET_DETECTION_RESULT: "myDetectionResult",
+  GET_COMMUNITY_FEED: "communityPosts",
 };

--- a/web/src/constants/reportReasons.ts
+++ b/web/src/constants/reportReasons.ts
@@ -6,3 +6,13 @@ export const REPORT_REASONS = [
   "상업적 광고 또는 홍보성 콘텐츠",
   "기타 커뮤니티 운영 방침 위반",
 ];
+export const REPORT_REASON_MAP: Record<string, ReportType> = {
+  "허위 정보 또는 조작된 내용": "FAKE",
+  "혐오 표현 또는 차별적 발언": "HATE",
+  "개인정보 노출": "PRIVACY",
+  "중복 또는 도배성 게시글": "SPAM",
+  "상업적 광고 또는 홍보성 콘텐츠": "AD",
+  "기타 커뮤니티 운영 방침 위반": "POLICY",
+};
+
+export type ReportType = "FAKE" | "HATE" | "PRIVACY" | "SPAM" | "AD" | "POLICY";

--- a/web/src/hooks/mutations/useBlockUserMutation.ts
+++ b/web/src/hooks/mutations/useBlockUserMutation.ts
@@ -1,0 +1,21 @@
+import {
+  useMutation,
+  useQueryClient,
+  type QueryKey,
+} from "@tanstack/react-query";
+
+import { postBlock } from "@/apis/community/postBlock";
+
+export const useBlockUserMutation = (queryKeyToInvalidate: QueryKey) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: postBlock,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeyToInvalidate });
+    },
+    onError: () => {
+      alert("사용자 차단 실패");
+    },
+  });
+};

--- a/web/src/hooks/mutations/useReportPostMutation.ts
+++ b/web/src/hooks/mutations/useReportPostMutation.ts
@@ -4,30 +4,30 @@ import {
   type QueryKey,
 } from "@tanstack/react-query";
 
-import { deletePost } from "@/apis/community/deletePost";
+import { postReport } from "@/apis/community/postReport";
 
-interface UseDeletePostMutationOptions {
+interface UseReportPostMutationOptions {
   queryKeyToInvalidate: QueryKey;
   onSuccess?: () => void;
-  onError?: () => void;
+  onError?: (error: Error) => void;
 }
 
-export const useDeletePostMutation = ({
+export const useReportPostMutation = ({
   queryKeyToInvalidate,
   onSuccess,
   onError,
-}: UseDeletePostMutationOptions) => {
+}: UseReportPostMutationOptions) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: deletePost,
+    mutationFn: postReport,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeyToInvalidate });
       onSuccess?.();
     },
     onError: (error) => {
-      console.error("게시글 삭제 실패:", error);
-      onError?.();
+      alert("사용자 신고에 실패하였습니다");
+      onError?.(error);
     },
   });
 };

--- a/web/src/hooks/usePostMenu.ts
+++ b/web/src/hooks/usePostMenu.ts
@@ -1,0 +1,28 @@
+import { useState } from "react";
+
+type MenuType = "closed" | "menu" | "block" | "report" | "reportComplete";
+
+export const usePostMenu = () => {
+  const [menuState, setMenuState] = useState<{
+    type: MenuType;
+    postId: number | null;
+  }>({ type: "closed", postId: null });
+
+  const openMenu = (postId: number) => setMenuState({ type: "menu", postId });
+  const openBlockConfirm = (postId: number) =>
+    setMenuState({ type: "block", postId });
+  const openReportSheet = (postId: number) =>
+    setMenuState({ type: "report", postId });
+  const showReportComplete = () =>
+    setMenuState({ type: "reportComplete", postId: null });
+  const close = () => setMenuState({ type: "closed", postId: null });
+
+  return {
+    menuState,
+    openMenu,
+    openBlockConfirm,
+    openReportSheet,
+    showReportComplete,
+    close,
+  };
+};

--- a/web/src/hooks/useToast.ts
+++ b/web/src/hooks/useToast.ts
@@ -1,0 +1,14 @@
+import { useState } from "react";
+
+export const useToast = () => {
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
+
+  const showToast = (message: string, duration: number = 3500) => {
+    setToastMessage(message);
+    setTimeout(() => {
+      setToastMessage(null);
+    }, duration);
+  };
+
+  return { toastMessage, showToast };
+};

--- a/web/src/pages/communityFeed/CommunityFeed.tsx
+++ b/web/src/pages/communityFeed/CommunityFeed.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { useNavigate } from "react-router-dom";
 
@@ -7,16 +7,23 @@ import { useQuery } from "@tanstack/react-query";
 import { path } from "@/routes/path";
 
 import { getCommunityPosts } from "@/apis/community/getCommunityPosts";
+import { useBlockUserMutation } from "@/hooks/mutations/useBlockUserMutation";
+import { usePostMenu } from "@/hooks/usePostMenu";
 
 import { LoadingSpinner } from "@/components/animation/LoadingSpinner";
 import { AppHeader } from "@/components/common/AppHeader";
+import { BottomSheet } from "@/components/common/BottomSheet";
+import { ConfirmModal } from "@/components/common/ConfirmModal";
+import { ReportPostSheet } from "@/components/common/ReportPostSheet";
 import { SearchBarRedirect } from "@/components/common/SearchBarRedirect";
+import { SelectBox } from "@/components/common/SelectBox";
 import { ToTop } from "@/components/common/ToTop";
 import { CommunityFeedSortOptionDropdown } from "@/components/communityFeed/CommunityFeedSortOptionDropdown";
 import { CommunityFeedTab } from "@/components/communityFeed/CommunityFeedTab";
 import { CommunityPostPreview } from "@/components/communityFeed/CommunityPostPreview";
 
-import { COMMUNITY_FEED_TABS } from "@/constants/commnityFeedTabs";
+import { QUERY_KEYS } from "@/constants/apiConstants";
+import { BOARD_CATEGORY_MAP } from "@/constants/commnityFeedTabs";
 
 import WriteOff from "@/assets/icons/write_off.svg?react";
 
@@ -25,7 +32,7 @@ const sortToParam = (sort: string): string => {
 };
 
 const categoryToKeyword = (category: string): string => {
-  return COMMUNITY_FEED_TABS.includes(category) ? category : "";
+  return BOARD_CATEGORY_MAP[category] || "";
 };
 
 export const CommunityFeed = () => {
@@ -37,16 +44,45 @@ export const CommunityFeed = () => {
 
   const [selectedCategory, setSelectedCategory] = useState("신고합니다");
 
+  const communityPostsQueryKey = [
+    QUERY_KEYS.GET_COMMUNITY_FEED,
+    selectedCategory,
+    selectedSortOption,
+  ];
+
   const { data, isLoading, isError } = useQuery({
-    queryKey: ["communityPosts", selectedCategory, selectedSortOption],
+    queryKey: communityPostsQueryKey,
     queryFn: () =>
       getCommunityPosts({
-        keyword: categoryToKeyword(selectedCategory),
+        keyword: "",
+        category: categoryToKeyword(selectedCategory),
         sort: sortToParam(selectedSortOption),
-        page: 0,
+        page: 1,
         size: 20,
       }),
   });
+  const {
+    menuState,
+    openMenu,
+    openBlockConfirm,
+    openReportSheet,
+    showReportComplete,
+    close,
+  } = usePostMenu();
+
+  const { mutate: blockUser } = useBlockUserMutation(communityPostsQueryKey);
+
+  const handleBlockConfirm = () => {
+    if (menuState.postId) {
+      blockUser({ postId: menuState.postId });
+    }
+    close();
+  };
+
+  useEffect(() => {
+    console.log(data);
+  }, [data]);
+
   return (
     <div className="bg-bg-100 safearea flex h-screen flex-col">
       <AppHeader
@@ -93,7 +129,11 @@ export const CommunityFeed = () => {
             ) : (
               <div className="divide-bg-50 divide-y">
                 {data.content.map((post) => (
-                  <CommunityPostPreview key={post.id} {...post} />
+                  <CommunityPostPreview
+                    key={post.id}
+                    {...post}
+                    onOpenMenu={openMenu}
+                  />
                 ))}
               </div>
             )}
@@ -101,6 +141,46 @@ export const CommunityFeed = () => {
         )}
       </div>
       <ToTop scrollContainerRef={scrollRef} />
+      <BottomSheet isOpen={menuState.type === "menu"} onClose={close}>
+        <div className="mx-5 my-[1.875rem] flex flex-col gap-2.5">
+          <SelectBox
+            type="postMenu"
+            label="해당 유저 차단하기"
+            onClick={() => openBlockConfirm(menuState.postId!)}
+          />
+          <SelectBox
+            type="postMenu"
+            label="신고하기"
+            onClick={() => openReportSheet(menuState.postId!)}
+          />
+        </div>
+      </BottomSheet>
+
+      {menuState.type === "block" && (
+        <ConfirmModal
+          title="해당 유저를 차단하시겠어요?"
+          description={`차단 시, 이 유저의 게시물을\n더 이상 볼 수 없습니다.`}
+          confirmText="차단하기"
+          cancelText="취소"
+          onConfirm={handleBlockConfirm}
+          onCancel={close}
+        />
+      )}
+
+      <ReportPostSheet
+        isOpen={menuState.type === "report"}
+        postId={menuState.postId!}
+        onClose={close}
+        onReportComplete={showReportComplete}
+      />
+
+      {menuState.type === "reportComplete" && (
+        <ConfirmModal
+          title="신고가 정상적으로 접수되었습니다."
+          description={`접수해주신 내용을 바탕으로\n신속하고 정확하게 검토하겠습니다.`}
+          onConfirm={close}
+        />
+      )}
     </div>
   );
 };

--- a/web/src/pages/communityFeed/CommunityFeed.tsx
+++ b/web/src/pages/communityFeed/CommunityFeed.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 import { useNavigate } from "react-router-dom";
 
@@ -78,10 +78,6 @@ export const CommunityFeed = () => {
     }
     close();
   };
-
-  useEffect(() => {
-    console.log(data);
-  }, [data]);
 
   return (
     <div className="bg-bg-100 safearea flex h-screen flex-col">

--- a/web/src/pages/my/MyPostsPage.tsx
+++ b/web/src/pages/my/MyPostsPage.tsx
@@ -5,10 +5,12 @@ import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 
 import { getMypageCommunityPostsManagement } from "@/apis/my/getMypageCommunityPostsManagement";
+import { useToast } from "@/hooks/useToast";
 
 import { LoadingSpinner } from "@/components/animation/LoadingSpinner";
 import { AppHeader } from "@/components/common/AppHeader";
 import { NoResult } from "@/components/common/NoResult";
+import { Toast } from "@/components/common/Toast";
 import { ToTop } from "@/components/common/ToTop";
 import { MyPostsPreview } from "@/components/my/MyPostsPreview";
 
@@ -16,6 +18,8 @@ import { QUERY_KEYS } from "@/constants/apiConstants";
 
 export const MyPostsPage = () => {
   const navigate = useNavigate();
+
+  const { toastMessage, showToast } = useToast();
 
   const { data: myPosts, isLoading: isPostsLoading } = useQuery({
     queryKey: [QUERY_KEYS.MYPAGE_POST],
@@ -56,18 +60,20 @@ export const MyPostsPage = () => {
               <MyPostsPreview
                 key={post.id}
                 id={post.id}
-                nickname={post.nickname}
+                authorNickname={post.nickname}
                 title={post.title}
                 content={post.content}
-                date={post.createdAt}
+                createdAt={post.createdAt}
                 commentCount={post.commentCount}
-                images={post.imageUrls}
+                thumbnailUrls={post.imageUrls}
+                onDeleteSuccess={() => showToast("게시글이 삭제되었습니다.")}
               />
             ))}
           </div>
         )}
       </div>
       <ToTop bottom="2rem" scrollContainerRef={scrollRef} />
+      {toastMessage && <Toast text={toastMessage} icon="check" position="ai" />}
     </div>
   );
 };

--- a/web/src/pages/searchPage/SearchPage.tsx
+++ b/web/src/pages/searchPage/SearchPage.tsx
@@ -37,6 +37,10 @@ export const SearchPage = () => {
 
   const allPosts = data?.pages.flatMap((page) => page.content) || [];
 
+  useEffect(() => {
+    console.log(allPosts);
+  }, [allPosts]);
+
   const handleSearch = () => {
     if (query.trim() === "") return;
     setSearchKeyword(query.trim());

--- a/web/src/pages/searchPage/SearchPage.tsx
+++ b/web/src/pages/searchPage/SearchPage.tsx
@@ -4,6 +4,7 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { useInView } from "react-intersection-observer";
 
 import { getCommunityPosts } from "@/apis/community/getCommunityPosts";
+import { useDebounce } from "@/hooks/useDebounce";
 
 import { LoadingSpinner } from "@/components/animation/LoadingSpinner";
 import { NoResult } from "@/components/common/NoResult";
@@ -11,16 +12,20 @@ import { SearchBar } from "@/components/common/SearchBar";
 import { ToTop } from "@/components/common/ToTop";
 import { SearchResultPreview } from "@/components/searchPage/SearchResultPreview";
 
+import { QUERY_KEYS } from "@/constants/apiConstants";
+
 export const SearchPage = () => {
   const [query, setQuery] = useState("");
   const [searchKeyword, setSearchKeyword] = useState("");
+
+  const debouncedQuery = useDebounce(query, 1000);
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const { ref: inViewRef, inView } = useInView();
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteQuery({
-      queryKey: ["searchPosts", searchKeyword],
+      queryKey: [QUERY_KEYS.GET_SEARCH_RESULT, searchKeyword],
       queryFn: ({ pageParam = 1 }) =>
         getCommunityPosts({
           keyword: searchKeyword,
@@ -38,19 +43,12 @@ export const SearchPage = () => {
   const allPosts = data?.pages.flatMap((page) => page.content) || [];
 
   useEffect(() => {
-    console.log(allPosts);
-  }, [allPosts]);
-
-  const handleSearch = () => {
-    if (query.trim() === "") return;
-    setSearchKeyword(query.trim());
-  };
-
-  const handleKeyPress = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter") {
-      handleSearch();
+    if (debouncedQuery.trim() !== "") {
+      setSearchKeyword(debouncedQuery.trim());
+    } else {
+      setSearchKeyword("");
     }
-  };
+  }, [debouncedQuery]);
 
   useEffect(() => {
     if (inView && hasNextPage && !isFetchingNextPage) {
@@ -65,7 +63,6 @@ export const SearchPage = () => {
           placeholder="사기 사례를 검색해주세요."
           value={query}
           onChange={setQuery}
-          onKeyDown={handleKeyPress}
         />
       </header>
 

--- a/web/src/types/community/community.types.ts
+++ b/web/src/types/community/community.types.ts
@@ -1,12 +1,12 @@
 export type CommunityPost = {
   id: number;
-  nickname: string;
-  date: string;
+  authorNickname: string;
+  createdAt: string;
   category?: string;
   title: string;
   content: string;
   commentCount: number;
-  images?: string[];
+  thumbnailUrls?: string[];
 };
 
 export type Comment = {

--- a/web/src/utils/formatUTCtoKR.ts
+++ b/web/src/utils/formatUTCtoKR.ts
@@ -1,0 +1,23 @@
+/**
+ * ISO 형식의 날짜 문자열(UTC)을 한국 시간 기준 'YYYY.MM.DD' 형식으로 변환
+ * @param dateString - API로부터 받은 날짜/시간 문자열 (예: "2025-08-08T04:13:26")
+ * @returns {string} 변환된 날짜 문자열 (예: "2025.08.08")
+ */
+export const formatUTCtoKR = (dateString: string): string => {
+  const date = new Date(
+    dateString.endsWith("Z") ? dateString : dateString + "Z",
+  );
+
+  if (isNaN(date.getTime())) {
+    return "유효하지 않은 날짜";
+  }
+
+  return date
+    .toLocaleDateString("ko-KR", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    })
+    .replace(/\. /g, ".")
+    .slice(0, -1);
+};


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

Resolves: #113 

커뮤니티 피드 페이지의 API를 연동하여 실제 데이터를 표시하도록 구현했습니다. 사용자 경험 개선을 위해 게시글 메뉴(신고/차단)의 상태 관리 로직을 구현 및 리팩토링했으며, 검색 페이지에는 디바운싱(debouncing)을 적용하여 불필요한 API 요청을 줄이고 성능을 최적화했습니다.

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링


## 작업 내용

### 1. 커뮤니티 피드 API 연동 
- 쿼리 키 상수 지정
- 서버 데이터 응답 값에 따른 변수명 수정 
- 댓글 구역 임시 삭제 

### 2. 게시글 메뉴 상태 관리 리팩토링 
- 기존의 각 게시글 내부에 있던 메뉴 관련 상태를 페이지 레벨에서 관리하는 것으로 변경
- `usePostMesu` 커스텀 훅 생성하여 메뉴, 모달, 바텀 시트의 상태를 중앙에서 관리하도록 변경
- `useBlockUserMutation`, `useReportPostMutation` 훅이 `queryKey`를 인자로 받도록 하여, 추후 상세 페이지에서 사용 예정 

### 3. 검색 페이지 디바운싱 적용
- 앱이기에 기존 `Enter` 프레스 방식에서 입력값이 멈추면 1초 뒤 자동 검색 요청이 가도록 디바운싱 적용 
<!-- 작업 사항에 대한 설명을 적어주세요 -->

## 공유사항 to 리뷰어

- 코드 리뷰할 때에는 안보였던게 제가 직접 써보니까 리팩토링이 필요한 부분이 많이 보입니다.. 담주에 정리해서 보내드릴게욤 
- 상세 페이지까지 하고 1차 배포 시작하도록 하겠습니다아 
- 디버깅하면서 하느라 지우긴 했는데 혹시나 `console.log` 남아있는거 코멘트 달아주시면 지우겠습니다
<!-- 리뷰어가 중점적으로 봐주었으면 좋겠는 부분을 적어주세요 -->
<!-- 논의할 사항이 있다면 적어주세요 -->

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
