### PR TITLE
[FEAT]: 플랫폼별 로그인 버튼 조건부 노출

### DIFF
--- a/web/src/pages/auth/LoginPage.tsx
+++ b/web/src/pages/auth/LoginPage.tsx
@@ -1,5 +1,7 @@
 import { motion } from "motion/react";
 
+import { getPlatform } from "@/utils/getPlatform";
+
 import { Bubble } from "@/components/common/Bubble";
 import { AppleLogin } from "@/components/login/AppleLogin";
 import { KakaoLogin } from "@/components/login/KakaoLogin";
@@ -8,6 +10,8 @@ import CheatKeyLogo from "@/assets/logo/logo_cheatkey.svg?react";
 import CheatKeyTextLogo from "@/assets/logo/logo_cheatkey_text.svg?react";
 
 export const LoginPage = () => {
+  const platform = getPlatform();
+
   return (
     <div className="safearea relative flex h-screen w-full flex-1 flex-col items-center justify-center">
       <CheatKeyLogo className="h-auto w-28 -translate-y-10" />
@@ -28,7 +32,7 @@ export const LoginPage = () => {
         </motion.div>
         <div className="w-full">
           <KakaoLogin />
-          <AppleLogin />
+          {platform === "ios" && <AppleLogin />}
         </div>
       </div>
     </div>

--- a/web/src/utils/getPlatform.ts
+++ b/web/src/utils/getPlatform.ts
@@ -1,0 +1,13 @@
+export const getPlatform = (): "ios" | "android" | "web" => {
+  const ua = navigator.userAgent;
+
+  if (/android/i.test(ua)) {
+    return "android";
+  }
+
+  if (/iPhone|iPad|iPod/i.test(ua)) {
+    return "ios";
+  }
+
+  return "web";
+};


### PR DESCRIPTION
## 개요

iOS/Android 에 따라서 가능한 로그인 방식들을 조건부로 노출합니다.
Resolves: #116 

## PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가


## 작업 내용
### 1. `getPlatform` 유틸 함수 추가
- `getPlatform` 유틸 함수를 추가하여, 안드로이드 기기에서는 애플 로그인 버튼이 보이지 않도록 처리했습니다.
- iPod에 대해서는 논의한 바는 없지만, 혹시 몰라 함께 포함해두었습니다. 🧐
- 현재는 Android, iOS 외에 web 환경도 함께 분기하고 있습니다. 이 경우 두 로그인 버튼이 모두 노출되는데, 웹에서는 로그인 페이지 자체를 다르게 보여주는 게 나을지, 혹은 로그인 기능을 제외해도 괜찮을지는 아직 정해진 바가 없는 걸로 알아서, 결정되면 수정하겠습니다. 

## 공유사항 to 리뷰어

- iOS에서 두 버튼 다 잘 보이는지 확인 부탁드려요! 

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
