### PR TITLE
[STYLE]: 커뮤니티 상세보기 내용 스타일 변경

### DIFF
--- a/web/src/components/communityDetail/CommunityPostContent.tsx
+++ b/web/src/components/communityDetail/CommunityPostContent.tsx
@@ -66,9 +66,7 @@ export const CommunityPostContent = ({
 
         <div className="text-gray-system-100 body-1-bold">{title}</div>
 
-        <p className="text-gray-system-400 body-5-regular line-clamp-3">
-          {content}
-        </p>
+        <p className="text-gray-system-400 body-5-regular">{content}</p>
 
         {images.length > 0 && (
           <div


### PR DESCRIPTION
## 커뮤니티 상세보기 내용 스타일 변경
- `line-clamp-3` 적용으로 커뮤니티 상세보기 진입 시, 3줄밖에 안보이던 css 오류 수정