### PR TITLE
[FEAT]: 웹 뷰 리로드 리스너 구현

### DIFF
--- a/native/app/index.tsx
+++ b/native/app/index.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
+import { WebView as RNWebView } from "react-native-webview";
 import { StatusBar, StyleSheet, View, ActivityIndicator } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { createWebView } from "@webview-bridge/react-native";
@@ -15,6 +16,7 @@ const { WebView } = createWebView({
 
 export default function WebViewScreen() {
   const insets = useSafeAreaInsets();
+  const webViewRef = useRef<RNWebView>(null);
 
   const WEB_APP_URL = process.env.EXPO_PUBLIC_WEB_URL || "";
   const KAKAO_NATIVE_APP_KEY = process.env.EXPO_PUBLIC_KAKAO_NATIVE_KEY || "";
@@ -66,6 +68,7 @@ export default function WebViewScreen() {
         backgroundColor="transparent"
       />
       <WebView
+        ref={webViewRef}
         source={{ uri: initialUrl }}
         style={styles.webview}
         injectedJavaScript={injectedJavaScript}
@@ -91,6 +94,18 @@ export default function WebViewScreen() {
         contentInsetAdjustmentBehavior="never"
         onError={(e) => {
           console.error("WebView error:", e.nativeEvent);
+        }}
+        onMessage={(event) => {
+          try {
+            const message = JSON.parse(event.nativeEvent.data);
+            if (message.type === "requestSafeAreaInsets") {
+              webViewRef.current?.postMessage(
+                JSON.stringify({ type: "safeAreaInsets", insets })
+              );
+            }
+          } catch (e) {
+            console.error("WebView Reload Error:", e);
+          }
         }}
         onLoadEnd={handleWebViewLoadEnd}
       />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,7 +3,9 @@ import { RouterProvider } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { toast } from "react-toastify";
 
-import AppRouter from "./routes/AppRouter";
+import AppRouter from "@/routes/AppRouter";
+
+import { useSafeAreaListener } from "@/hooks/useSafeAreaListener";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -20,6 +22,7 @@ const queryClient = new QueryClient({
 });
 
 function App() {
+  useSafeAreaListener();
   return (
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={AppRouter} />

--- a/web/src/hooks/useSafeAreaListener.ts
+++ b/web/src/hooks/useSafeAreaListener.ts
@@ -1,0 +1,59 @@
+// @ts-nocheck
+import { useEffect } from "react";
+
+interface SafeAreaInsets {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}
+
+const applySafeAreaInsets = (insets: SafeAreaInsets) => {
+  const root = document.documentElement;
+  root.style.setProperty("--safe-area-inset-top", `${insets.top}px`);
+  root.style.setProperty("--safe-area-inset-right", `${insets.right}px`);
+  root.style.setProperty("--safe-area-inset-bottom", `${insets.bottom}px`);
+  root.style.setProperty("--safe-area-inset-left", `${insets.left}px`);
+};
+
+export const useSafeAreaListener = () => {
+  useEffect(() => {
+    const handleMessage = (event: Event) => {
+      try {
+        const data = JSON.parse((event as MessageEvent).data);
+
+        if (data.type === "safeAreaInsets") {
+          applySafeAreaInsets(data.insets);
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    };
+
+    const handleWindowMessage = (event: MessageEvent) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.type === "safeAreaInsets") {
+          applySafeAreaInsets(data.insets);
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    };
+
+    if (window.ReactNativeWebView) {
+      document.addEventListener("message", handleMessage);
+
+      window.ReactNativeWebView.postMessage(
+        JSON.stringify({ type: "requestSafeAreaInsets" }),
+      );
+    }
+
+    window.addEventListener("message", handleWindowMessage);
+
+    return () => {
+      document.removeEventListener("message", handleMessage);
+      window.removeEventListener("message", handleWindowMessage);
+    };
+  }, []);
+};


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

Resolves: #128 
웹 뷰 리로드 리스너 구현

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## 작업 내용

### 1. 웹 뷰 리로드 시, inset 감지 못하는 현상 발생 -> 리로드 리스너 구현
- 메시지 기반 통신을 통해, 웹 뷰 리로드 시, `insets` 값 재전달 로직 구현 

<!-- 작업 사항에 대한 설명을 적어주세요 -->


## 공유사항 to 리뷰어

- 리로드 시,  `insets` 값이 사라지는 현상 수정 

<!-- 리뷰어가 중점적으로 봐주었으면 좋겠는 부분을 적어주세요 -->
<!-- 논의할 사항이 있다면 적어주세요 -->

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
