### PR TITLE
[FEAT]: URL 분석 토스트 및 세부 수정사항 반영

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,7 +9,7 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: 0,
-      throwOnError: true,
+      throwOnError: false,
     },
     mutations: {
       onError: (error) => {

--- a/web/src/components/analyze/TabSwitcher.tsx
+++ b/web/src/components/analyze/TabSwitcher.tsx
@@ -20,7 +20,7 @@ export const TabSwitcher = ({
   useEffect(() => {
     const indicator = indicatorRef.current;
     if (indicator) {
-      if (activeTab === "url") {
+      if (activeTab === "case") {
         indicator.style.transform = "translateX(0%)";
       } else {
         indicator.style.transform = "translateX(100%)";
@@ -44,22 +44,6 @@ export const TabSwitcher = ({
       <button
         type="button"
         role="tab"
-        aria-selected={activeTab === "url"}
-        aria-controls={ariaControls}
-        onClick={() => onTabChange("url")}
-        className={cn(
-          "rounded-full px-7 py-2 text-sm transition-colors duration-300 ease-in-out",
-          {
-            "text-gray-system-500": activeTab === "url",
-            "text-gray-system-700": activeTab !== "url",
-          },
-        )}
-      >
-        URL 분석
-      </button>
-      <button
-        type="button"
-        role="tab"
         aria-selected={activeTab === "case"}
         aria-controls={ariaControls}
         onClick={() => onTabChange("case")}
@@ -72,6 +56,22 @@ export const TabSwitcher = ({
         )}
       >
         사례 분석
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={activeTab === "url"}
+        aria-controls={ariaControls}
+        onClick={() => onTabChange("url")}
+        className={cn(
+          "rounded-full px-7 py-2 text-sm transition-colors duration-300 ease-in-out",
+          {
+            "text-gray-system-500": activeTab === "url",
+            "text-gray-system-700": activeTab !== "url",
+          },
+        )}
+      >
+        URL 분석
       </button>
     </div>
   );

--- a/web/src/components/common/ImageWithLoader.tsx
+++ b/web/src/components/common/ImageWithLoader.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+
+import { cn } from "@/utils/cn";
+
+interface ImageWithLoaderProps
+  extends React.ImgHTMLAttributes<HTMLImageElement> {
+  rounded?: "md" | "xl";
+}
+
+export const ImageWithLoader = ({
+  src,
+  alt,
+  className,
+  rounded = "md",
+  ...props
+}: ImageWithLoaderProps) => {
+  const [isLoading, setIsLoading] = useState(true);
+
+  return (
+    <div className="relative h-full w-full">
+      {isLoading && (
+        <div
+          className={cn(
+            "bg-bg-50 absolute inset-0 h-full w-full animate-pulse",
+            {
+              "rounded-xl": rounded === "xl",
+              "rounded-md": rounded === "md",
+            },
+          )}
+        />
+      )}
+      <img
+        src={src}
+        alt={alt}
+        className={cn(
+          "h-full w-full",
+          {
+            "opacity-0": isLoading,
+            "opacity-100 transition-opacity duration-300": !isLoading,
+          },
+          className,
+        )}
+        onLoad={() => setIsLoading(false)}
+        onError={() => setIsLoading(false)}
+        {...props}
+      />
+    </div>
+  );
+};

--- a/web/src/components/common/ImageWithLoader.tsx
+++ b/web/src/components/common/ImageWithLoader.tsx
@@ -17,7 +17,7 @@ export const ImageWithLoader = ({
   const [isLoading, setIsLoading] = useState(true);
 
   return (
-    <div className="relative h-full w-full">
+    <div className="relative h-fit w-fit">
       {isLoading && (
         <div
           className={cn(

--- a/web/src/components/common/ReportPostSheet.tsx
+++ b/web/src/components/common/ReportPostSheet.tsx
@@ -64,7 +64,7 @@ export const ReportPostSheet = ({
 
   return (
     <BottomSheet isOpen={isOpen} onClose={onClose}>
-      <div className="mb-3 flex flex-col gap-5 text-center">
+      <div className="flex max-h-[85vh] flex-col gap-5 overflow-y-auto pb-10 text-center">
         <h2 className="text-gray-system-100 head-3-bold my-3">신고하기</h2>
         <div>
           <p className="text-gray-system-200 head-4-semibold mb-1">

--- a/web/src/components/common/Toast.tsx
+++ b/web/src/components/common/Toast.tsx
@@ -26,7 +26,7 @@ const ICON_MAP = {
 };
 
 const POSITION_MAP: Record<ToastProps["position"], string> = {
-  ai: "3rem",
+  ai: "3.5rem",
   write: "5.875rem",
 };
 

--- a/web/src/components/common/Toast.tsx
+++ b/web/src/components/common/Toast.tsx
@@ -9,17 +9,20 @@ import AlertIcon from "@/assets/icons/alert.svg?react";
 import CheckOnIcon from "@/assets/icons/check_on.svg?react";
 import WarningIcon from "@/assets/icons/warning.svg?react";
 
+export type ToastIconType = "warning" | "check" | "alert";
+
 interface ToastProps {
-  icon?: "warning" | "check" | "alert";
+  icon?: ToastIconType;
   text: string;
+  fontSize?: "sm" | "lg";
   position: "ai" | "write";
   onDone?: () => void;
 }
 
 const ICON_MAP = {
-  warning: <WarningIcon />,
-  check: <CheckOnIcon />,
-  alert: <AlertIcon />,
+  warning: <WarningIcon className="h-6 w-6 shrink-0" />,
+  check: <CheckOnIcon className="h-6 w-6 shrink-0" />,
+  alert: <AlertIcon className="h-6 w-6 shrink-0" />,
 };
 
 const POSITION_MAP: Record<ToastProps["position"], string> = {
@@ -36,6 +39,7 @@ const toastVariants = {
 export const Toast = ({
   icon = "warning",
   text,
+  fontSize = "lg",
   position,
   onDone,
 }: ToastProps) => {
@@ -67,7 +71,7 @@ export const Toast = ({
           exit="exit"
           transition={{ ease: "easeInOut", duration: 0.5 }}
           className={cn(
-            "bg-primary-600 fixed z-50 mx-5 flex h-[3.375rem] items-center gap-2 rounded-xl px-4",
+            "bg-primary-600 fixed z-50 mx-5 flex items-center gap-2.5 rounded-xl p-4",
           )}
           style={{
             bottom: POSITION_MAP[position],
@@ -77,7 +81,14 @@ export const Toast = ({
           role="alert"
         >
           {ICON_MAP[icon]}
-          <p className="body-2-medium text-base-0">{text}</p>
+          <p
+            className={cn("text-base-0", {
+              "body-4-medium": fontSize === "sm",
+              "body-2-medium": fontSize === "lg",
+            })}
+          >
+            {text}
+          </p>
         </motion.div>
       )}
     </AnimatePresence>,

--- a/web/src/components/communityDetail/CommunityPostContent.tsx
+++ b/web/src/components/communityDetail/CommunityPostContent.tsx
@@ -6,6 +6,8 @@ import { ImageCloseUpModal } from "@/components/communityDetail/ImageCloseUpModa
 
 import TemporaryProfilePicIcon from "@/assets/images/temporary_profile_pic.png";
 
+import { ImageWithLoader } from "../common/ImageWithLoader";
+
 type CommunityPostContentProps = {
   postId: number;
   nickname: string;
@@ -81,17 +83,21 @@ export const CommunityPostContent = ({
             {images
               .slice(0, images.length >= 3 ? images.length : 2)
               .map((img, i) => (
-                <img
+                <div
                   key={`${img}-${i}`}
-                  src={img}
-                  alt={`${nickname}님의 게시글 이미지 ${i + 1}`}
-                  className={cn("h-[6.875rem] rounded-lg object-cover", {
+                  className={cn("h-[6.875rem] overflow-hidden rounded-lg", {
                     "w-full": images.length === 1,
                     "w-1/2": images.length === 2,
                     "w-[8.125rem] flex-shrink-0": images.length >= 3,
                   })}
                   onClick={() => openImageSlider(images, i)}
-                />
+                >
+                  <ImageWithLoader
+                    src={img}
+                    alt={`${nickname}님의 게시글 이미지 ${i + 1}`}
+                    className="object-cover"
+                  />
+                </div>
               ))}
           </div>
         )}

--- a/web/src/components/communityFeed/CommunityFeedSortOptionDropdown.tsx
+++ b/web/src/components/communityFeed/CommunityFeedSortOptionDropdown.tsx
@@ -1,5 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 
+import { motion, AnimatePresence } from "framer-motion";
+
 import { cn } from "@/utils/cn";
 
 import DropDownIcon from "@/assets/icons/dropdown.svg?react";
@@ -33,47 +35,63 @@ export const CommunityFeedSortOptionDropdown = ({
   }, []);
 
   return (
-    <div
-      ref={dropdownRef}
-      className="relative flex w-full justify-end pt-[0.875rem]"
-    >
+    <div ref={dropdownRef} className="relative flex w-full justify-end pt-3.5">
       <button
         aria-haspopup="listbox"
         aria-expanded={isOpen}
         aria-controls="scam-type-listbox"
         onClick={() => setIsOpen(!isOpen)}
-        className="text-gray-system-600 body-1-bold flex h-[2.625rem] w-[6.25rem] items-center justify-end gap-[0.0625rem]"
+        className="text-gray-system-600 body-1-bold flex h-[2.625rem] w-25 items-center justify-end gap-0.5"
       >
         {selectedSortOption}
         <DropDownIcon className="ml-1 h-4 w-4" aria-hidden />
       </button>
 
-      {isOpen && (
-        <ul className="bg-bg-50 caption-1-medium absolute top-full z-10 mt-[0.5rem] w-[6.25rem] overflow-hidden rounded-lg">
-          {SORT_OPTIONS.map((option) => {
-            const isSelected = selectedSortOption === option;
+      <AnimatePresence>
+        {isOpen && (
+          <motion.ul
+            initial={{ opacity: 0, y: -10, scale: 0.95 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -10, scale: 0.95 }}
+            transition={{
+              duration: 0.2,
+              ease: "easeIn",
+            }}
+            className="bg-bg-50 caption-1-medium absolute top-full z-10 mt-2 w-25 overflow-hidden rounded-lg"
+            style={{ transformOrigin: "top" }}
+          >
+            {SORT_OPTIONS.map((option, index) => {
+              const isSelected = selectedSortOption === option;
 
-            return (
-              <li
-                key={option}
-                onClick={() => {
-                  onSelect(option);
-                  setIsOpen(false);
-                }}
-                aria-selected={isSelected}
-                className={cn(
-                  "h-[2.375rem] cursor-pointer p-[0.625rem]",
-                  isSelected
-                    ? "bg-base-50 text-gray-system-100"
-                    : "bg-bg-50 text-gray-system-500",
-                )}
-              >
-                {option}
-              </li>
-            );
-          })}
-        </ul>
-      )}
+              return (
+                <motion.li
+                  key={option}
+                  initial={{ opacity: 0, x: -10 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  transition={{
+                    duration: 0.15,
+                    delay: index * 0.05,
+                    ease: "easeIn",
+                  }}
+                  onClick={() => {
+                    onSelect(option);
+                    setIsOpen(false);
+                  }}
+                  aria-selected={isSelected}
+                  className={cn(
+                    "h-[2.375rem] cursor-pointer p-2.5 transition-colors duration-150",
+                    isSelected
+                      ? "bg-base-50 text-gray-system-100"
+                      : "bg-bg-50 text-gray-system-500",
+                  )}
+                >
+                  {option}
+                </motion.li>
+              );
+            })}
+          </motion.ul>
+        )}
+      </AnimatePresence>
     </div>
   );
 };

--- a/web/src/components/communityFeed/CommunityFeedTab.tsx
+++ b/web/src/components/communityFeed/CommunityFeedTab.tsx
@@ -12,7 +12,7 @@ export const CommunityFeedTab = ({
   setActiveTab,
 }: CommunityFeedTabProps) => {
   return (
-    <div className="border-gray-system-700 border-b">
+    <div>
       <div className="flex w-full justify-between">
         {COMMUNITY_FEED_TABS.map((tab) => {
           const isActive = activeTab === tab;
@@ -25,10 +25,10 @@ export const CommunityFeedTab = ({
               aria-label={`${tab} 탭`}
               onClick={() => setActiveTab(tab)}
               className={cn(
-                "h-10 flex-1 border-b",
+                "h-10 flex-1 transition-colors duration-300 ease-in-out",
                 isActive
-                  ? "text-primary-400 border-primary-400 body-1-bold border-b-[1px]"
-                  : "text-gray-system-600 border-bg-50 body-2-medium border-b-[0.5px]",
+                  ? "text-primary-400 border-primary-400 body-1-bold border-b-[1.5px]"
+                  : "text-gray-system-600 border-bg-50 body-2-medium border-b-[1px]",
               )}
             >
               {tab}

--- a/web/src/components/communityFeed/CommunityPostPreview.tsx
+++ b/web/src/components/communityFeed/CommunityPostPreview.tsx
@@ -13,6 +13,8 @@ import CommentIcon from "@/assets/icons/comment.svg?react";
 //TODO: @tifsy 임시 프로필 이미지 제거
 import TemporaryProfilePicIcon from "@/assets/images/temporary_profile_pic.png";
 
+import { ImageWithLoader } from "../common/ImageWithLoader";
+
 interface CommunityPostPreviewProps extends CommunityPost {
   onOpenMenu: (postId: number) => void;
 }
@@ -73,16 +75,20 @@ export const CommunityPostPreview = ({
           {thumbnailUrls
             .slice(0, thumbnailUrls.length >= 3 ? thumbnailUrls.length : 2)
             .map((img, i) => (
-              <img
+              <div
                 key={`${img}-${i}`}
-                src={img}
-                alt={`게시글 이미지 ${i + 1}`}
-                className={cn("h-[6.875rem] rounded-lg object-cover", {
+                className={cn("h-[6.875rem] overflow-hidden rounded-lg", {
                   "w-full": thumbnailUrls.length === 1,
                   "w-1/2": thumbnailUrls.length === 2,
                   "w-[8.125rem] flex-shrink-0": thumbnailUrls.length >= 3,
                 })}
-              />
+              >
+                <ImageWithLoader
+                  src={img}
+                  alt={`게시글 이미지 ${i + 1}`}
+                  className="object-cover"
+                />
+              </div>
             ))}
         </div>
       )}

--- a/web/src/components/content/ContentDetailMain.tsx
+++ b/web/src/components/content/ContentDetailMain.tsx
@@ -25,6 +25,8 @@ import {
 import android from "@/assets/logo/logo_store_android.svg";
 import ios from "@/assets/logo/logo_store_ios.svg";
 
+import { ImageWithLoader } from "../common/ImageWithLoader";
+
 interface ContentDetailMainProps {
   category: ContentCategory;
   title: string;
@@ -51,10 +53,11 @@ export const ContentDetailMain = ({
 
   return (
     <main className={cn("flex flex-1 flex-col gap-[1.875rem]", className)}>
-      <img
+      <ImageWithLoader
         src={image}
         alt={`${title}의 메인 사진`}
         className="aspect-[335/200] h-auto w-full rounded-xl"
+        rounded="xl"
       />
       <div className={cn("flex flex-col gap-[1.875rem]")}>
         {sections.map((section, index) => (

--- a/web/src/components/content/ContentPreview.tsx
+++ b/web/src/components/content/ContentPreview.tsx
@@ -12,6 +12,8 @@ import type {
 
 import { AUTHOR_INFO_CONFIG } from "@/constants/contentPageConstants";
 
+import { ImageWithLoader } from "../common/ImageWithLoader";
+
 interface ContentPreviewProps extends ContentType {
   author: ContentCategory;
 }
@@ -56,9 +58,10 @@ export const ContentPreview = ({
       className="bg-bg-50 flex cursor-pointer flex-col gap-2.5 rounded-2xl p-3"
       onClick={handleNavigate}
     >
-      <img
+      <ImageWithLoader
         src={image}
         alt={`${title}의 미리보기 이미지`}
+        rounded="xl"
         className="h-[8.75rem] w-full rounded-xl bg-white object-cover"
       />
       <h3 className="body-1-bold text-gray-system-50 mb-1 w-full truncate">

--- a/web/src/components/my/MyAnalysisPageTab.tsx
+++ b/web/src/components/my/MyAnalysisPageTab.tsx
@@ -13,7 +13,7 @@ export const MyAnalysisPageTab = ({
 }: MyAnalysisPageTabProps) => {
   return (
     //TODO: @tifsy 커뮤니티 피드랑 이 페이지 탭 컴포넌트화
-    <div className="border-gray-system-700 mx-5 border-b">
+    <div className="mx-5">
       <div className="flex w-full justify-between">
         {MY_ANALYSIS_PAGE_TABS.map((tab) => {
           const isActive = activeTab === tab;
@@ -26,10 +26,10 @@ export const MyAnalysisPageTab = ({
               aria-label={`${tab} 탭`}
               onClick={() => setActiveTab(tab)}
               className={cn(
-                "h-10 flex-1 border-b-[0.5px]",
+                "h-10 flex-1 transition-colors duration-300 ease-in-out",
                 isActive
-                  ? "text-primary-400 border-primary-400 body-1-bold border-b"
-                  : "text-gray-system-600 border-bg-50 body-2-medium",
+                  ? "text-primary-400 border-primary-400 body-1-bold border-b-[1.5px]"
+                  : "text-gray-system-600 border-bg-50 body-2-medium border-b",
               )}
             >
               {tab}

--- a/web/src/components/my/MyPostsPreview.tsx
+++ b/web/src/components/my/MyPostsPreview.tsx
@@ -18,6 +18,8 @@ import CommentIcon from "@/assets/icons/comment.svg?react";
 import RemoveIcon from "@/assets/icons/remove.svg?react";
 import TemporaryProfilePicIcon from "@/assets/images/temporary_profile_pic.png";
 
+import { ImageWithLoader } from "../common/ImageWithLoader";
+
 interface MyPostsPreviewProps extends CommunityPost {
   onDeleteSuccess: () => void;
 }
@@ -100,16 +102,20 @@ export const MyPostsPreview = ({
           {thumbnailUrls
             .slice(0, thumbnailUrls.length >= 3 ? thumbnailUrls.length : 2)
             .map((img, i) => (
-              <img
+              <div
                 key={`${img}-${i}`}
-                src={img}
-                alt={`게시글 이미지 ${i + 1}`}
-                className={cn("h-[6.875rem] rounded-lg object-cover", {
+                className={cn("h-[6.875rem] overflow-hidden rounded-lg", {
                   "w-full": thumbnailUrls.length === 1,
                   "w-1/2": thumbnailUrls.length === 2,
                   "w-[8.125rem] flex-shrink-0": thumbnailUrls.length >= 3,
                 })}
-              />
+              >
+                <ImageWithLoader
+                  src={img}
+                  alt={`게시글 이미지 ${i + 1}`}
+                  className="object-cover"
+                />
+              </div>
             ))}
         </div>
       )}

--- a/web/src/hooks/useAnalyzePage.ts
+++ b/web/src/hooks/useAnalyzePage.ts
@@ -13,6 +13,7 @@ import { postAnalyzeURL } from "@/apis/analyze/postAnalyzeURL";
 import type { AnalyzeResponse } from "@/types/analyzeResult/analyzeResult.types";
 
 import type { TabCategory } from "@/components/analyze/TabSwitcher";
+import type { ToastIconType } from "@/components/common/Toast";
 
 import { analysisTabsData } from "@/constants/analyze/page/analyzePageConstants";
 
@@ -29,7 +30,11 @@ export const useAnalyzePage = () => {
 
   const [activeTab, setActiveTab] = useState<TabCategory>("case");
   const [inputValue, setInputValue] = useState<string>("");
-  const [toastMessage, setToastMessage] = useState<string | null>("");
+  const [toastInfo, setToastInfo] = useState<{
+    message: string;
+    icon: ToastIconType;
+  } | null>(null);
+  const [hasShownUrlToast, setHasShownUrlToast] = useState<boolean>(false);
 
   const {
     mutate: analyze,
@@ -59,9 +64,9 @@ export const useAnalyzePage = () => {
     },
   });
 
-  const showToast = (message: string) => {
-    setToastMessage(message);
-    setTimeout(() => setToastMessage(null), 3500);
+  const showToast = (message: string, icon: ToastIconType = "warning") => {
+    setToastInfo({ message, icon });
+    setTimeout(() => setToastInfo(null), 3500);
   };
 
   const currentTabInfo = analysisTabsData.find((tab) => tab.id === activeTab)!;
@@ -71,13 +76,21 @@ export const useAnalyzePage = () => {
   const handleNavigateBack = () => navigate(-1);
 
   const handleTabChange = (tab: TabCategory) => {
+    if (!hasShownUrlToast && tab === "url") {
+      showToast(
+        `URL 자체 기준으로, 피싱이 포함된 내용 자체는 사례 검색이나 추가 확인이 필요할 수 있어요.`,
+        "alert",
+      );
+      setHasShownUrlToast(true);
+    }
+
     setActiveTab(tab);
     setInputValue("");
   };
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setToastMessage(null);
+    setToastInfo(null);
     if (!isButtonEnabled) return;
 
     if (activeTab === "url") {
@@ -103,6 +116,6 @@ export const useAnalyzePage = () => {
     handleNavigateBack,
     handleTabChange,
     handleSubmit,
-    toastMessage,
+    toastInfo,
   };
 };

--- a/web/src/hooks/useAnalyzePage.ts
+++ b/web/src/hooks/useAnalyzePage.ts
@@ -27,7 +27,7 @@ const CASE_ERROR_MSG = "분석할 수 없는 유형이에요.";
 export const useAnalyzePage = () => {
   const navigate = useNavigate();
 
-  const [activeTab, setActiveTab] = useState<TabCategory>("url");
+  const [activeTab, setActiveTab] = useState<TabCategory>("case");
   const [inputValue, setInputValue] = useState<string>("");
   const [toastMessage, setToastMessage] = useState<string | null>("");
 

--- a/web/src/hooks/useAnalyzePage.ts
+++ b/web/src/hooks/useAnalyzePage.ts
@@ -71,9 +71,12 @@ export const useAnalyzePage = () => {
 
   const currentTabInfo = analysisTabsData.find((tab) => tab.id === activeTab)!;
   const controlledPanelId = "analysis-panel";
-  const isButtonEnabled = inputValue !== "" && !isAnalyzePending;
+  const isButtonEnabled =
+    inputValue !== "" && !isAnalyzePending && toastInfo === null;
 
   const handleNavigateBack = () => navigate(-1);
+
+  const handleNavigateCommunity = () => navigate(path.community.feed);
 
   const handleTabChange = (tab: TabCategory) => {
     if (!hasShownUrlToast && tab === "url") {
@@ -114,6 +117,7 @@ export const useAnalyzePage = () => {
     isAnalyzeSuccess,
     isButtonEnabled,
     handleNavigateBack,
+    handleNavigateCommunity,
     handleTabChange,
     handleSubmit,
     toastInfo,

--- a/web/src/pages/analyze/AnalyzePage.tsx
+++ b/web/src/pages/analyze/AnalyzePage.tsx
@@ -22,7 +22,7 @@ export const AnalyzePage = () => {
     handleNavigateBack,
     handleTabChange,
     handleSubmit,
-    toastMessage,
+    toastInfo,
   } = useAnalyzePage();
 
   if (isAnalyzePending || isAnalyzeSuccess) {
@@ -69,8 +69,8 @@ export const AnalyzePage = () => {
           className="mt-[3.125rem]"
         />
       </form>
-      {toastMessage && (
-        <Toast position="ai" icon="warning" text={toastMessage} />
+      {toastInfo && (
+        <Toast position="ai" icon={toastInfo.icon} text={toastInfo.message} />
       )}
       {/*
       // TODO: @Ki-Tak 1차 배포 이후 가이드 작업 예정

--- a/web/src/pages/analyze/AnalyzePage.tsx
+++ b/web/src/pages/analyze/AnalyzePage.tsx
@@ -7,7 +7,7 @@ import { BottomFullButton } from "@/components/common/BottomFullButton";
 import { FormTextarea } from "@/components/common/FormTextarea";
 import { Toast } from "@/components/common/Toast";
 
-//import GuideIcon from "@/assets/icons/arrow_right_bold.svg?react";
+import GuideIcon from "@/assets/icons/arrow_right_bold.svg?react";
 
 export const AnalyzePage = () => {
   const {
@@ -20,6 +20,7 @@ export const AnalyzePage = () => {
     isAnalyzeSuccess,
     isButtonEnabled,
     handleNavigateBack,
+    handleNavigateCommunity,
     handleTabChange,
     handleSubmit,
     toastInfo,
@@ -72,19 +73,17 @@ export const AnalyzePage = () => {
       {toastInfo && (
         <Toast position="ai" icon={toastInfo.icon} text={toastInfo.message} />
       )}
-      {/*
-      // TODO: @Ki-Tak 1차 배포 이후 가이드 작업 예정
+
       <a
-        href="/" 
+        onClick={handleNavigateCommunity}
         className="body-4-medium text-gray-system-600 mt-10 flex items-center rounded-full bg-[#3c5187]/30 px-4 py-2"
       >
-        AI 분석 가이드가 궁금하다면?
+        함께 얘기 나누기
         <GuideIcon
           aria-hidden="true"
           className="text-gray-system-600 h-5 w-5"
         />
       </a>
-       */}
     </main>
   );
 };

--- a/web/src/pages/communityDetail/CommunityDetail.tsx
+++ b/web/src/pages/communityDetail/CommunityDetail.tsx
@@ -49,7 +49,7 @@ export const CommunityDetail = () => {
     isLoading: isPostDetailLoading,
     isError: isPostDetailError,
   } = useQuery({
-    queryKey: commentListQueryKey,
+    queryKey: postDetailQueryKey,
     queryFn: () => getCommunityDetail({ postId: parseInt(postId!) }),
     enabled: !!postId,
     staleTime: 10 * 1000,
@@ -68,7 +68,7 @@ export const CommunityDetail = () => {
     isLoading: isCommentListLoading,
     isError: isCommentListError,
   } = useQuery({
-    queryKey: postDetailQueryKey,
+    queryKey: commentListQueryKey,
     queryFn: () => getCommentList({ postId: parseInt(postId!) }),
     staleTime: 10 * 1000,
     enabled: !!postId,
@@ -159,13 +159,13 @@ export const CommunityDetail = () => {
         />
 
         <div className="flex flex-1 flex-col items-center justify-center gap-4">
-          <p className="text-gray-system-400">
+          <p className="body-2-medium text-gray-system-600">
             게시글을 불러오는 데 실패했습니다.
           </p>
 
           <button
             onClick={() => navigate(-1)}
-            className="bg-bg-50 body-2-medium rounded-lg px-4 py-2 text-white"
+            className="bg-primary-400 body-2-medium rounded-lg px-4 py-2 text-white"
           >
             뒤로 가기
           </button>

--- a/web/src/pages/my/MyAnalysisPage.tsx
+++ b/web/src/pages/my/MyAnalysisPage.tsx
@@ -37,7 +37,7 @@ export const MyAnalysisPage = () => {
         title="분석 내역 보기"
         className="bg-bg-100"
       />
-      <div className="divide-bg-50 divide-y overflow-hidden overflow-y-auto pt-11">
+      <div className="overflow-hidden overflow-y-auto pt-11">
         <MyAnalysisPageTab activeTab={activeTab} setActiveTab={setActiveTab} />
         <MyAnalysisList period={period} />
       </div>

--- a/web/src/styles/style.css
+++ b/web/src/styles/style.css
@@ -32,6 +32,20 @@
     --safe-area-inset-bottom: env(safe-area-inset-bottom, 20px);
     --safe-area-inset-left: env(safe-area-inset-left, 0px);
   }
+
+  body {
+    -webkit-touch-callout: none;
+    -webkit-user-drag: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
+
+  img {
+    -webkit-user-drag: none;
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

Resolves: #163 

사용자 경험을 개선하기 위한 여러 UI 수정 및 버그 픽스를 진행하였습니다. 

- URL 분석 토스트
- 신고 바텀시트 스타일 수정
- 이미지 로드 UX 향상
- 커뮤니티 상세 페이지 오류 대응
- 커뮤니티 탭 및 마이페이지 분석 내용 스타일 오류 수정 및 전환 애니메이션 추가 
- 커뮤니티 정렬 애니메이션 추가 
- 화면 롱프레스 이벤트 방지 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링


## 작업 내용

### 1. 분석 페이지 UX 개선

- `case` 탭에서 `url` 탭으로 최초 전환 시, 안내 토스트 메시지가 한 번만 표시되도록 `useState` 플래그를 추가했습니다.

### 2. 이미지 로딩 UX 개선

- 이미지가 로드되기 전에 로딩 스피너를 표시하는 `ImageWithLoader` 재사용 컴포넌트를 구현했습니다.

- `<img>` 태그의 `onLoad` 이벤트를 사용하여 로딩 상태를 관리하고, 로딩 완료 시 이미지가 부드럽게 나타나도록 하여 사용자가 로딩 상태를 명확히 인지할 수 있도록 했습니다.

### 3. 커뮤니티 상세 페이지 오류 수정

- `useQuery`의 `queryKey`가 서로 뒤바뀌어 할당되었던 문제를 수정했습니다. 

- 리액트 쿼리 에러 핸들링 옵션을 수정하였습니다. 이제 API 통신 실패 시 또는 없는 상세 페이지의 경우, 의도한 대로 커스텀 에러 UI가 정상적으로 표시됩니다.

### 4. 세부 수정사항 반영 

- 신고하기 바텀 시트 버튼 바텀패딩 수정 
- 커뮤니티 정렬 기준 애니메이션 추가 
- 커뮤니티 탭 및 분석 내역 탭 스타일 오류 수정  

### 5. 전역 스타일 수정

- 웹뷰 환경에서 롱프레스 시 나타나는 링크/이미지 미리보기 팝업을 방지하기 위해 `-webkit-touch-callout: none;` 및 `user-select: none;` 등 CSS 속성을 전역으로 적용했습니다.

<!-- 작업 사항에 대한 설명을 적어주세요 -->

## 스크린샷

https://github.com/user-attachments/assets/155a344d-f357-45a5-a24a-a2461ed06205


https://github.com/user-attachments/assets/e60970bf-a0c9-4740-b83e-7c5613c720df


https://github.com/user-attachments/assets/8bc6c912-4779-4eaa-a56a-565bc6da3323


https://github.com/user-attachments/assets/773421fb-574e-4802-8327-02ab654de69d


<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->

## 공유사항 to 리뷰어

- 데모데이 전, 오류 사항 있으면 알려주시면 수정하겠습니다. 

<!-- 리뷰어가 중점적으로 봐주었으면 좋겠는 부분을 적어주세요 -->
<!-- 논의할 사항이 있다면 적어주세요 -->

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
