### PR TITLE
[STYLE]: 툴팁 버블 z-index 오류 수정 및 콘텐츠 페이지 이미지 로더 적용 방식 변경

### DIFF
--- a/web/src/components/common/ImageWithLoader.tsx
+++ b/web/src/components/common/ImageWithLoader.tsx
@@ -17,7 +17,7 @@ export const ImageWithLoader = ({
   const [isLoading, setIsLoading] = useState(true);
 
   return (
-    <div className="relative h-fit w-fit">
+    <div className="relative h-full w-full">
       {isLoading && (
         <div
           className={cn(
@@ -33,10 +33,10 @@ export const ImageWithLoader = ({
         src={src}
         alt={alt}
         className={cn(
-          "h-full w-full",
+          "h-full w-full transition-opacity duration-300",
           {
             "opacity-0": isLoading,
-            "opacity-100 transition-opacity duration-300": !isLoading,
+            "opacity-100": !isLoading,
           },
           className,
         )}

--- a/web/src/components/communityDetail/CommunityPostContent.tsx
+++ b/web/src/components/communityDetail/CommunityPostContent.tsx
@@ -1,12 +1,11 @@
 import { useImageSlider } from "@/hooks/useImageSlider";
 import { cn } from "@/utils/cn";
 
+import { ImageWithLoader } from "@/components/common/ImageWithLoader";
 import { PostMenuButton } from "@/components/common/PostMenuButton";
 import { ImageCloseUpModal } from "@/components/communityDetail/ImageCloseUpModal";
 
 import TemporaryProfilePicIcon from "@/assets/images/temporary_profile_pic.png";
-
-import { ImageWithLoader } from "../common/ImageWithLoader";
 
 type CommunityPostContentProps = {
   postId: number;

--- a/web/src/components/communityFeed/CommunityPostPreview.tsx
+++ b/web/src/components/communityFeed/CommunityPostPreview.tsx
@@ -6,14 +6,13 @@ import type { CommunityPost } from "@/types/community/community.types";
 import { cn } from "@/utils/cn";
 import { formatUTCtoKR } from "@/utils/formatUTCtoKR";
 
+import { ImageWithLoader } from "@/components/common/ImageWithLoader";
 import { NameTag } from "@/components/common/NameTag";
 import { PostMenuButton } from "@/components/common/PostMenuButton";
 
 import CommentIcon from "@/assets/icons/comment.svg?react";
 //TODO: @tifsy 임시 프로필 이미지 제거
 import TemporaryProfilePicIcon from "@/assets/images/temporary_profile_pic.png";
-
-import { ImageWithLoader } from "../common/ImageWithLoader";
 
 interface CommunityPostPreviewProps extends CommunityPost {
   onOpenMenu: (postId: number) => void;

--- a/web/src/components/content/ContentDetailHeader.tsx
+++ b/web/src/components/content/ContentDetailHeader.tsx
@@ -57,7 +57,7 @@ export const ContentDetailHeader = () => {
   return (
     <header
       className={cn(
-        "h-header bg-bg-100 fixed flex w-full max-w-3xl items-center px-5",
+        "h-header bg-bg-100 fixed z-10 flex w-full max-w-3xl items-center px-5",
         {
           "justify-between": getPlatform() !== "web",
           "justify-end": getPlatform() === "web",

--- a/web/src/components/content/ContentDetailMain.tsx
+++ b/web/src/components/content/ContentDetailMain.tsx
@@ -12,6 +12,7 @@ import type {
 import { cn } from "@/utils/cn";
 import { getPlatform } from "@/utils/getPlatform";
 
+import { ImageWithLoader } from "@/components/common/ImageWithLoader";
 import { ContentRedirectBanner } from "@/components/content/ContentRedirectBanner";
 
 import {
@@ -24,8 +25,6 @@ import {
 //import safe from "@/assets/images/result/safe.svg";
 import android from "@/assets/logo/logo_store_android.svg";
 import ios from "@/assets/logo/logo_store_ios.svg";
-
-import { ImageWithLoader } from "../common/ImageWithLoader";
 
 interface ContentDetailMainProps {
   category: ContentCategory;
@@ -53,12 +52,14 @@ export const ContentDetailMain = ({
 
   return (
     <main className={cn("flex flex-1 flex-col gap-[1.875rem]", className)}>
-      <ImageWithLoader
-        src={image}
-        alt={`${title}의 메인 사진`}
-        className="aspect-[335/200] h-auto w-full rounded-xl"
-        rounded="xl"
-      />
+      <div className="aspect-[335/200] h-auto w-full rounded-xl">
+        <ImageWithLoader
+          src={image}
+          alt={`${title}의 메인 사진`}
+          className="aspect-[335/200] rounded-xl"
+          rounded="xl"
+        />
+      </div>
       <div className={cn("flex flex-col gap-[1.875rem]")}>
         {sections.map((section, index) => (
           <section

--- a/web/src/components/content/ContentPreview.tsx
+++ b/web/src/components/content/ContentPreview.tsx
@@ -10,9 +10,9 @@ import type {
   SourceStateKey,
 } from "@/types/content/content.types";
 
-import { AUTHOR_INFO_CONFIG } from "@/constants/contentPageConstants";
+import { ImageWithLoader } from "@/components/common/ImageWithLoader";
 
-import { ImageWithLoader } from "../common/ImageWithLoader";
+import { AUTHOR_INFO_CONFIG } from "@/constants/contentPageConstants";
 
 interface ContentPreviewProps extends ContentType {
   author: ContentCategory;
@@ -58,12 +58,14 @@ export const ContentPreview = ({
       className="bg-bg-50 flex cursor-pointer flex-col gap-2.5 rounded-2xl p-3"
       onClick={handleNavigate}
     >
-      <ImageWithLoader
-        src={image}
-        alt={`${title}의 미리보기 이미지`}
-        rounded="xl"
-        className="h-[8.75rem] w-full rounded-xl bg-white object-cover"
-      />
+      <div className="h-[8.75rem] w-full">
+        <ImageWithLoader
+          src={image}
+          alt={`${title}의 미리보기 이미지`}
+          className="rounded-xl object-cover"
+          rounded="xl"
+        />
+      </div>
       <h3 className="body-1-bold text-gray-system-50 mb-1 w-full truncate">
         {title}
       </h3>


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

Resolves: #165
툴팁 버블 `z-index` 오류 수정 및 콘텐츠 페이지 이미지 로더 적용 방식 변경

## PR 유형

어떤 변경 사항이 있나요?

- [x] CSS 등 사용자 UI 디자인 변경

## 작업 내용

### 1. 툴팁 버블 `z-index` 오류 수정 
- 이미지에 툴팁 버블이 가려지던 현상 `ContentDetailHeader`에 `z-index`  10 입력으로 해결

### 2. 콘텐츠 페이지 이미지 로더 적용 방식 변경 
- 특정 비율이 필요한 콘텐츠 페이지의 경우, `<div>` 태그로 감싸서 컴포넌트 호출로 변경 
<!-- 작업 사항에 대한 설명을 적어주세요 -->


## 공유사항 to 리뷰어

- 간단한 css 수정입니다. 
<!-- 리뷰어가 중점적으로 봐주었으면 좋겠는 부분을 적어주세요 -->
<!-- 논의할 사항이 있다면 적어주세요 -->

