### PR TITLE
[FEAT]: 마이페이지 분석 내역 기간 연동 및 검색바 활성화 유무 색상 적용 

### DIFF
--- a/web/src/components/common/SearchBar.tsx
+++ b/web/src/components/common/SearchBar.tsx
@@ -33,12 +33,18 @@ export const SearchBar = ({
   const isSearchBarFilled = value.trim().length > 0;
 
   return (
-    <div className="mb-[0.625rem] flex w-full items-center gap-[5px]">
+    <div className="flex w-full items-center gap-[5px]">
       <button className="text-base-0 h-6 w-6" onClick={() => navigate(-1)}>
         <PrevIcon />
       </button>
       <div className="bg-base-75 flex h-[2.625rem] w-full items-center gap-1 rounded-full px-3">
-        <SearchIcon className="text-gray-system-600 h-5 w-5" aria-hidden />
+        <SearchIcon
+          className={cn("h-5 w-5", {
+            "text-gray-system-600": isSearchBarFilled,
+            "text-gray-system-700": !isSearchBarFilled,
+          })}
+          aria-hidden
+        />
         <input
           ref={inputRef}
           type="text"

--- a/web/src/components/my/MyAnalysisList.tsx
+++ b/web/src/components/my/MyAnalysisList.tsx
@@ -27,7 +27,7 @@ export const MyAnalysisList = ({ period }: MyAnalysisListProps) => {
     getNextPageParam: (lastPage) => {
       return lastPage.last ? undefined : lastPage.number + 1;
     },
-    staleTime: 60 * 1000,
+    staleTime: 5 * 60 * 1000,
   });
 
   if (isLoading) {

--- a/web/src/hooks/useAnalyzePage.ts
+++ b/web/src/hooks/useAnalyzePage.ts
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import { useNavigate } from "react-router-dom";
 
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { AxiosError } from "axios";
 import { z } from "zod";
 
@@ -16,6 +16,7 @@ import type { TabCategory } from "@/components/analyze/TabSwitcher";
 import type { ToastIconType } from "@/components/common/Toast";
 
 import { analysisTabsData } from "@/constants/analyze/page/analyzePageConstants";
+import { QUERY_KEYS } from "@/constants/apiConstants";
 
 interface AnalyzeVariables {
   activeTab: TabCategory;
@@ -27,6 +28,7 @@ const CASE_ERROR_MSG = "분석할 수 없는 유형이에요.";
 
 export const useAnalyzePage = () => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const [activeTab, setActiveTab] = useState<TabCategory>("case");
   const [inputValue, setInputValue] = useState<string>("");
@@ -54,6 +56,9 @@ export const useAnalyzePage = () => {
         const resultId = data.detectionId;
         navigate(path.analyze.specific.result(resultId), { state: data });
       }
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.GET_MY_ANALYZE_HISTORY],
+      });
     },
     onError: () => {
       if (activeTab === "url") {

--- a/web/src/pages/my/MyAnalysisPage.tsx
+++ b/web/src/pages/my/MyAnalysisPage.tsx
@@ -18,9 +18,9 @@ export const MyAnalysisPage = () => {
     switch (tab) {
       case "오늘":
         return "today";
-      case "이번 주":
+      case "일주일":
         return "week";
-      case "이번 달":
+      case "3개월":
         return "month";
       default:
         return "today";


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

Resolves: #167 

마이페이지 분석 내역 기간 연동 및 검색바 활성화 유무 색상 적용 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)

## 작업 내용

### 1. 마이페이지 분석 내역 기간 연동 
- 마이페이지 분석 내역 매칭이 되지 않았던 변수 수정 
- 분석 하기시, 마이페이지 분석 내역 쿼리키 무효화 
- 마이페이지 분석 내역 `staleTime` 시간 수정 ( 10초 -> 5분 ) 

### 2. 검색바 활성화 유무 색상 적용 
- 검색창 활성화에 따른 차등 색상 적용 

## 스크린샷

https://github.com/user-attachments/assets/dd937dc6-e601-48f1-be14-79383e8d5112

https://github.com/user-attachments/assets/c28a26e8-6033-44e2-9bd2-487fecdf1666


<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->

## 공유사항 to 리뷰어

- 간단한 오류랑 스타일 수정하였습니다. 

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
